### PR TITLE
chore(db): add idempotent status template backfill script

### DIFF
--- a/src/lib/graphql/plugins/defaults/DefaultStatusTemplates.plugin.ts
+++ b/src/lib/graphql/plugins/defaults/DefaultStatusTemplates.plugin.ts
@@ -16,51 +16,58 @@ import { wrapPlans } from "postgraphile/utils";
 import type { InsertProject, InsertStatusTemplate } from "lib/db/schema";
 import type { PlanWrapperFn } from "postgraphile/utils";
 
-const DEFAULT_STATUS_TEMPLATES: Omit<InsertStatusTemplate, "organizationId">[] =
-  [
-    {
-      name: "open",
-      displayName: "Open",
-      color: "#3b82f6",
-      description: "New and awaiting review",
-      sortOrder: 0,
-    },
-    {
-      name: "under_review",
-      displayName: "Under Review",
-      color: "#f59e0b",
-      description: "Being evaluated by the team",
-      sortOrder: 1,
-    },
-    {
-      name: "planned",
-      displayName: "Planned",
-      color: "#8b5cf6",
-      description: "Scheduled for implementation",
-      sortOrder: 2,
-    },
-    {
-      name: "in_progress",
-      displayName: "In Progress",
-      color: "#10b981",
-      description: "Currently being worked on",
-      sortOrder: 3,
-    },
-    {
-      name: "completed",
-      displayName: "Completed",
-      color: "#22c55e",
-      description: "Done",
-      sortOrder: 4,
-    },
-    {
-      name: "closed",
-      displayName: "Closed",
-      color: "#6b7280",
-      description: "Will not be implemented",
-      sortOrder: 5,
-    },
-  ];
+/**
+ * Default status templates seeded for every organization.
+ *
+ * @knipignore also consumed by the backfill script in the knip-ignored scripts dir
+ */
+export const DEFAULT_STATUS_TEMPLATES: Omit<
+  InsertStatusTemplate,
+  "organizationId"
+>[] = [
+  {
+    name: "open",
+    displayName: "Open",
+    color: "#3b82f6",
+    description: "New and awaiting review",
+    sortOrder: 0,
+  },
+  {
+    name: "under_review",
+    displayName: "Under Review",
+    color: "#f59e0b",
+    description: "Being evaluated by the team",
+    sortOrder: 1,
+  },
+  {
+    name: "planned",
+    displayName: "Planned",
+    color: "#8b5cf6",
+    description: "Scheduled for implementation",
+    sortOrder: 2,
+  },
+  {
+    name: "in_progress",
+    displayName: "In Progress",
+    color: "#10b981",
+    description: "Currently being worked on",
+    sortOrder: 3,
+  },
+  {
+    name: "completed",
+    displayName: "Completed",
+    color: "#22c55e",
+    description: "Done",
+    sortOrder: 4,
+  },
+  {
+    name: "closed",
+    displayName: "Closed",
+    color: "#6b7280",
+    description: "Will not be implemented",
+    sortOrder: 5,
+  },
+];
 
 const createDefaultStatusTemplates = (): PlanWrapperFn =>
   EXPORTABLE(

--- a/src/scripts/db/backfillStatusTemplates.ts
+++ b/src/scripts/db/backfillStatusTemplates.ts
@@ -1,0 +1,68 @@
+/**
+ * @file Backfill default status templates for organizations that have projects
+ * but no status templates.
+ *
+ * Default status templates are normally seeded on `createProject`
+ * (DefaultStatusTemplatesPlugin). Organizations whose projects predate that
+ * plugin, or where the seed side-effect silently failed, end up with no
+ * templates, which blocks feedback reporting in the app. This script is
+ * idempotent (ON CONFLICT DO NOTHING) and safe to run against any environment.
+ *
+ * Usage: bun --env-file .env.local src/scripts/db/backfillStatusTemplates.ts
+ */
+
+import { drizzle } from "drizzle-orm/node-postgres";
+import { projects, statusTemplates } from "lib/db/schema";
+import { DEFAULT_STATUS_TEMPLATES } from "lib/graphql/plugins/defaults/DefaultStatusTemplates.plugin";
+import { Pool } from "pg";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+
+if (!DATABASE_URL) {
+  console.error("[Backfill] DATABASE_URL is not set");
+  process.exit(1);
+}
+
+const pool = new Pool({ connectionString: DATABASE_URL });
+
+try {
+  const db = drizzle({ client: pool, casing: "snake_case" });
+
+  const projectOrgs = await db
+    .selectDistinct({ organizationId: projects.organizationId })
+    .from(projects);
+  const templateOrgs = await db
+    .selectDistinct({ organizationId: statusTemplates.organizationId })
+    .from(statusTemplates);
+
+  const seeded = new Set(templateOrgs.map((row) => row.organizationId));
+  const missing = projectOrgs
+    .map((row) => row.organizationId)
+    .filter((organizationId) => !seeded.has(organizationId));
+
+  if (missing.length === 0) {
+    console.info("[Backfill] All project organizations already have templates");
+  } else {
+    for (const organizationId of missing) {
+      await db
+        .insert(statusTemplates)
+        .values(
+          DEFAULT_STATUS_TEMPLATES.map((template) => ({
+            ...template,
+            organizationId,
+          })),
+        )
+        .onConflictDoNothing({
+          target: [statusTemplates.organizationId, statusTemplates.name],
+        });
+    }
+    console.info(
+      `[Backfill] Seeded default status templates for ${missing.length} organization(s)`,
+    );
+  }
+} catch (err) {
+  console.error("[Backfill] Failed:", err);
+  process.exit(1);
+} finally {
+  await pool.end();
+}


### PR DESCRIPTION
## Description

##### Task link: N/A

Fixes the recurring "Status templates are not configured. Please contact a workspace admin." error when reporting feedback, for organizations created before `DefaultStatusTemplatesPlugin` existed (or where its seed side-effect silently failed).

- Adds `src/scripts/db/backfillStatusTemplates.ts`: seeds the 6 default status templates for every org that has projects but no templates.
- Idempotent (ON CONFLICT DO NOTHING), safe for any environment.
- Reuses the plugin's `DEFAULT_STATUS_TEMPLATES` (now exported) as the single source of truth.

## Test Steps

1. `bun --env-file .env.local src/scripts/db/backfillStatusTemplates.ts`
2. Confirm orgs with projects but no templates now have the 6 defaults; re-running is a no-op.