### PR TITLE
feat: heuristic feedback triage (type + sentiment)

### DIFF
--- a/src/lib/feedback/signal.test.ts
+++ b/src/lib/feedback/signal.test.ts
@@ -124,15 +124,28 @@ describe("buildPostProvenanceSignal", () => {
     description: "It would be easier on the eyes.",
   };
 
-  test("produces a published widget feedback signal linked to the post", () => {
+  test("produces a published widget signal linked to the post", () => {
     const signal = buildPostProvenanceSignal(base);
     expect(signal.source).toBe("widget");
-    expect(signal.type).toBe("feedback");
     expect(signal.status).toBe("published");
     expect(signal.postId).toBe("post-1");
     expect(signal.projectId).toBe("proj-1");
     expect(signal.organizationId).toBe("org-1");
     expect(signal.userId).toBe("user-1");
+  });
+
+  test("triages the content into type and sentiment", () => {
+    const feature = buildPostProvenanceSignal(base);
+    expect(feature.type).toBe("feedback");
+    expect(feature.sentiment).toBe("neutral");
+
+    const bug = buildPostProvenanceSignal({
+      ...base,
+      title: "App crashes on save",
+      description: "It is broken and I hate it",
+    });
+    expect(bug.type).toBe("bug");
+    expect(bug.sentiment).toBe("negative");
   });
 
   test("combines title and description into rawContent", () => {

--- a/src/lib/feedback/signal.ts
+++ b/src/lib/feedback/signal.ts
@@ -5,6 +5,8 @@
  * truth for that validation.
  */
 
+import { heuristicTriage } from "./triage";
+
 import type { InsertSignal } from "lib/db/schema";
 
 /** Where a signal originated. */
@@ -91,13 +93,21 @@ export const buildPostProvenanceSignal = (post: {
   userId?: string | null;
   title?: string | null;
   description?: string | null;
-}): InsertSignal => ({
-  source: DEFAULT_SIGNAL_SOURCE,
-  type: "feedback",
-  status: "published",
-  organizationId: post.organizationId,
-  projectId: post.projectId,
-  userId: post.userId ?? null,
-  postId: post.postId,
-  rawContent: [post.title, post.description].filter(Boolean).join("\n\n"),
-});
+}): InsertSignal => {
+  const rawContent = [post.title, post.description]
+    .filter(Boolean)
+    .join("\n\n");
+  const { type, sentiment } = heuristicTriage(rawContent);
+
+  return {
+    source: DEFAULT_SIGNAL_SOURCE,
+    type,
+    status: "published",
+    organizationId: post.organizationId,
+    projectId: post.projectId,
+    userId: post.userId ?? null,
+    postId: post.postId,
+    rawContent,
+    sentiment,
+  };
+};

--- a/src/lib/feedback/triage.test.ts
+++ b/src/lib/feedback/triage.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+
+import { heuristicTriage } from "./triage";
+
+describe("heuristicTriage type classification", () => {
+  test("classifies crashes and errors as bugs", () => {
+    expect(heuristicTriage("The app crashes when I click save").type).toBe(
+      "bug",
+    );
+    expect(heuristicTriage("Export is broken and throws an error").type).toBe(
+      "bug",
+    );
+  });
+
+  test("classifies appreciation as praise", () => {
+    expect(heuristicTriage("I love the new dashboard, great work!").type).toBe(
+      "praise",
+    );
+  });
+
+  test("classifies interrogatives as questions", () => {
+    expect(heuristicTriage("How do I export my data?").type).toBe("question");
+  });
+
+  test("defaults to feedback when nothing else matches", () => {
+    expect(heuristicTriage("Please add a dark mode toggle").type).toBe(
+      "feedback",
+    );
+  });
+
+  test("prioritises bug over other signals", () => {
+    expect(heuristicTriage("Why does it crash every time?").type).toBe("bug");
+  });
+});
+
+describe("heuristicTriage sentiment", () => {
+  test("detects negative sentiment", () => {
+    expect(heuristicTriage("This is broken and I hate it").sentiment).toBe(
+      "negative",
+    );
+  });
+
+  test("detects positive sentiment", () => {
+    expect(heuristicTriage("Love it, this is awesome").sentiment).toBe(
+      "positive",
+    );
+  });
+
+  test("falls back to neutral", () => {
+    expect(heuristicTriage("Please add dark mode").sentiment).toBe("neutral");
+  });
+
+  test("tolerates empty content", () => {
+    const result = heuristicTriage("");
+    expect(result.type).toBe("feedback");
+    expect(result.sentiment).toBe("neutral");
+  });
+});

--- a/src/lib/feedback/triage.ts
+++ b/src/lib/feedback/triage.ts
@@ -1,0 +1,50 @@
+/**
+ * Feedback triage (the "brain"). Classifies a piece of feedback content into a
+ * signal type and a sentiment.
+ *
+ * The default provider is a dependency-free heuristic so triage works without
+ * any external service. A hosted provider (e.g. an LLM router) can be swapped in
+ * later by replacing `heuristicTriage` at its call sites.
+ */
+
+import type { SignalType } from "./signal";
+
+type Sentiment = "positive" | "neutral" | "negative";
+
+interface TriageResult {
+  type: SignalType;
+  sentiment: Sentiment;
+}
+
+const BUG_PATTERN =
+  /\b(bug|broken|breaks?|crash\w*|error|errors|fail\w*|throws?|doesn'?t work|not working|won'?t|can'?t|cannot)\b/i;
+const PRAISE_PATTERN =
+  /\b(love|great|awesome|amazing|excellent|fantastic|wonderful|thank you|thanks|nice work|well done)\b/i;
+const QUESTION_PATTERN =
+  /(\?|\b(how|why|what|when|where|which|can i|is it possible|do you)\b)/i;
+
+const NEGATIVE_PATTERN =
+  /\b(hate|broken|crash\w*|terrible|awful|bad|worse|worst|useless|frustrat\w*|annoying|disappoint\w*|error|fail\w*|slow|buggy)\b/i;
+const POSITIVE_PATTERN =
+  /\b(love|great|awesome|amazing|excellent|good|nice|perfect|fantastic|wonderful|thank you|thanks)\b/i;
+
+const classifyType = (content: string): SignalType => {
+  if (BUG_PATTERN.test(content)) return "bug";
+  if (PRAISE_PATTERN.test(content)) return "praise";
+  if (QUESTION_PATTERN.test(content)) return "question";
+  return "feedback";
+};
+
+const classifySentiment = (content: string): Sentiment => {
+  if (NEGATIVE_PATTERN.test(content)) return "negative";
+  if (POSITIVE_PATTERN.test(content)) return "positive";
+  return "neutral";
+};
+
+/**
+ * Default dependency-free triage provider.
+ */
+export const heuristicTriage = (content: string): TriageResult => ({
+  type: classifyType(content),
+  sentiment: classifySentiment(content),
+});


### PR DESCRIPTION
## Description

##### Task link: N/A

Phase 2 foundation: a dependency-free 'brain' that auto-classifies feedback, working today without any external service and swappable for a hosted provider later.

- **feat(feedback)**: `heuristicTriage` derives a signal **type** (bug/praise/question/feedback, bug-first priority) and **sentiment** (negative/positive/neutral) from content. 9 tests.
- **feat(feedback)**: `buildPostProvenanceSignal` now triages the post content, so every app post's provenance signal is auto-classified (type + sentiment) instead of a hard-coded `feedback`.

No schema change. When a hosted provider (LLM router) is available, replace `heuristicTriage` at its call sites.

## Test Steps

1. `bun test` -> 29 pass
2. `bun run check` + `bunx tsc --noEmit` + `bun knip` -> clean