### PR TITLE
test: db integration harness for the signal write path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,22 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: backfeed_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/backfeed_test
     steps:
       - uses: actions/checkout@v4
 
@@ -41,6 +57,9 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Run migrations
+        run: bun src/scripts/db/migrate.ts
 
       - name: Test
         run: bun test

--- a/src/lib/feedback/signalProvenance.integration.test.ts
+++ b/src/lib/feedback/signalProvenance.integration.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+
+import { posts, projects, signals, users } from "../db/schema";
+import { buildPostProvenanceSignal } from "./signal";
+
+/**
+ * Integration test for the signal provenance write path. Runs against a real
+ * Postgres (skipped when DATABASE_URL is unset, e.g. local `bun test` without a
+ * database). CI provides a Postgres service and runs migrations first.
+ */
+const DATABASE_URL = process.env.DATABASE_URL;
+
+describe.skipIf(!DATABASE_URL)("signal provenance (db integration)", () => {
+  const runId = crypto.randomUUID();
+  // Organization ids are uuids (from Gatekeeper); the project column is uuid in the db
+  const organizationId = crypto.randomUUID();
+
+  let pool: Pool;
+  let db: ReturnType<typeof drizzle>;
+  let userId: string;
+  let projectId: string;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    db = drizzle({ client: pool, casing: "snake_case" });
+
+    const [user] = await db
+      .insert(users)
+      .values({
+        identityProviderId: crypto.randomUUID(),
+        name: "Integration Test User",
+        email: `itest-${runId}@example.com`,
+      })
+      .returning();
+    userId = user.id;
+
+    const [project] = await db
+      .insert(projects)
+      .values({
+        organizationId,
+        name: "Integration Test Project",
+        slug: `itest-${runId}`,
+      })
+      .returning();
+    projectId = project.id;
+  });
+
+  afterAll(async () => {
+    // Deleting the project cascades to its posts and signals
+    await db.delete(projects).where(eq(projects.id, projectId));
+    await db.delete(users).where(eq(users.id, userId));
+    await pool.end();
+  });
+
+  test("persists a triaged provenance signal linked to the post", async () => {
+    const [post] = await db
+      .insert(posts)
+      .values({
+        projectId,
+        userId,
+        title: "App crashes on save",
+        description: "It is broken and I hate it",
+      })
+      .returning();
+
+    await db.insert(signals).values(
+      buildPostProvenanceSignal({
+        postId: post.id,
+        projectId,
+        organizationId,
+        userId,
+        title: post.title,
+        description: post.description,
+      }),
+    );
+
+    const [signal] = await db
+      .select()
+      .from(signals)
+      .where(eq(signals.postId, post.id));
+
+    expect(signal).toBeDefined();
+    expect(signal.source).toBe("widget");
+    expect(signal.status).toBe("published");
+    expect(signal.organizationId).toBe(organizationId);
+    // triaged from the post content
+    expect(signal.type).toBe("bug");
+    expect(signal.sentiment).toBe("negative");
+  });
+});


### PR DESCRIPTION
## Description

##### Task link: N/A

Adds the repo's first **database-backed integration test** and the CI infra to run it, addressing the gap that plan side-effects were only unit-tested.

- **ci**: the Test job now provisions a Postgres 17 service and runs migrations before `bun test`. `DATABASE_URL` is exported to the job.
- **test**: `signalProvenance.integration.test.ts` exercises the provenance write path against real Postgres (seed user/project/post -> build + insert provenance signal -> assert it persists with the triaged type/sentiment). Skips when `DATABASE_URL` is unset; cleans up its own rows.

Verified locally against the dev DB (passes with DATABASE_URL, skips without).

> Surfaced (not fixed here): `project.organization_id` is `uuid` in the DB but `text` in the Drizzle schema, a pre-existing schema/DB drift.

## Test Steps

1. CI: Test job stands up Postgres, migrates, runs `bun test` (integration test runs).
2. Local: `DATABASE_URL=… bun test` -> integration passes; `bun test` -> it skips.