### PR TITLE
fix(entitlements): unlimited feedback users on free tier to match catalog

### DIFF
--- a/src/lib/entitlements/index.ts
+++ b/src/lib/entitlements/index.ts
@@ -21,7 +21,11 @@ const APP_ID = "backfeed";
  */
 const DEFAULT_LIMITS: Record<string, Record<string, number>> = {
   max_projects: { free: 1 },
-  max_feedback_users: { free: 15 },
+  // -1 = unlimited, mirroring the product catalog SSOT (omni-api planConfigs:
+  // backfeed feedback is unlimited on every tier). The prior `15` was stale
+  // drift that silently capped feedback for any org not yet provisioned in
+  // Aether
+  max_feedback_users: { free: -1 },
   max_comments_per_post: { free: 100 },
   max_members: { free: 5, pro: -1, team: -1 },
   max_admins: { free: 1, pro: 3, team: -1 },


### PR DESCRIPTION
## Problem
The local `DEFAULT_LIMITS` fallback (used when an org has no Aether billing record) capped `max_feedback_users` at **15** for the free tier. This contradicts:
- the product catalog SSOT (`omni-api` `planConfigs.ts`), which sets `max_feedback_users: -1` (unlimited) on **every** backfeed tier, and
- the free-tier marketing copy ("Unlimited feedback submissions").

Any org not yet provisioned in Aether silently hit a 15-unique-feedback-user cap per project ("Maximum number of unique users providing feedback has been reached").

## Fix
Set the fallback `max_feedback_users.free` to `-1` to mirror the catalog. Removing a cap cannot regress existing users.

## Notes
- No board is currently near 15 (busiest has 3 unique users), so this is a latent-bug fix rather than an active unblock.
- Other `DEFAULT_LIMITS` also drift from the catalog (`max_projects` 1 vs 2, `max_comments_per_post` 100 vs 50). Left as-is here to avoid lowering live limits; tracked for separate reconciliation.