### PR TITLE
feat(status): add showOnBoard flag to status templates

### DIFF
--- a/src/generated/drizzle/0029_sloppy_toad.sql
+++ b/src/generated/drizzle/0029_sloppy_toad.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "status_template" ADD COLUMN "show_on_board" boolean;

--- a/src/generated/drizzle/meta/0029_snapshot.json
+++ b/src/generated/drizzle/meta/0029_snapshot.json
@@ -1,0 +1,2682 @@
+{
+  "id": "65921d01-d76f-47f3-992e-d22dccb107c7",
+  "prevId": "33658a72-ced4-4184-8410-6fa66bc0aa61",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.attachment": {
+      "name": "attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachment_id_index": {
+          "name": "attachment_id_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachment_post_id_index": {
+          "name": "attachment_post_id_index",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachment_user_id_index": {
+          "name": "attachment_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachment_post_id_post_id_fk": {
+          "name": "attachment_post_id_post_id_fk",
+          "tableFrom": "attachment",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attachment_user_id_user_id_fk": {
+          "name": "attachment_user_id_user_id_fk",
+          "tableFrom": "attachment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment": {
+      "name": "comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comment_id_index": {
+          "name": "comment_id_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comment_post_id_index": {
+          "name": "comment_post_id_index",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comment_user_id_index": {
+          "name": "comment_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comment_post_id_post_id_fk": {
+          "name": "comment_post_id_post_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_user_id_user_id_fk": {
+          "name": "comment_user_id_user_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_parent_id_comment_id_fk": {
+          "name": "comment_parent_id_comment_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "comment",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preference": {
+      "name": "notification_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_updates": {
+          "name": "post_updates",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_preference_user_id_index": {
+          "name": "notification_preference_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_preference_user_id_user_id_fk": {
+          "name": "notification_preference_user_id_user_id_fk",
+          "tableFrom": "notification_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post": {
+      "name": "post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_template_id": {
+          "name": "status_template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'widget'"
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_tags": {
+          "name": "ai_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duplicate_of_id": {
+          "name": "duplicate_of_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "shipped_at": {
+          "name": "shipped_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_id_index": {
+          "name": "post_id_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_project_id_index": {
+          "name": "post_project_id_index",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_user_id_index": {
+          "name": "post_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_status_template_id_index": {
+          "name": "post_status_template_id_index",
+          "columns": [
+            {
+              "expression": "status_template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_duplicate_of_id_index": {
+          "name": "post_duplicate_of_id_index",
+          "columns": [
+            {
+              "expression": "duplicate_of_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_cluster_id_index": {
+          "name": "post_cluster_id_index",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_project_id_project_id_fk": {
+          "name": "post_project_id_project_id_fk",
+          "tableFrom": "post",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_user_id_user_id_fk": {
+          "name": "post_user_id_user_id_fk",
+          "tableFrom": "post",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_status_template_id_status_template_id_fk": {
+          "name": "post_status_template_id_status_template_id_fk",
+          "tableFrom": "post",
+          "tableTo": "status_template",
+          "columnsFrom": [
+            "status_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "post_duplicate_of_id_post_id_fk": {
+          "name": "post_duplicate_of_id_post_id_fk",
+          "tableFrom": "post",
+          "tableTo": "post",
+          "columnsFrom": [
+            "duplicate_of_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "post_cluster_id_signal_cluster_id_fk": {
+          "name": "post_cluster_id_signal_cluster_id_fk",
+          "tableFrom": "post",
+          "tableTo": "signal_cluster",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_project_number_unique": {
+          "name": "post_project_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_reference": {
+      "name": "post_reference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_post_id": {
+          "name": "target_post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_kind": {
+          "name": "ref_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_reference_id_index": {
+          "name": "post_reference_id_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_reference_target_idx": {
+          "name": "post_reference_target_idx",
+          "columns": [
+            {
+              "expression": "target_post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_reference_source_idx": {
+          "name": "post_reference_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_reference_organization_id_idx": {
+          "name": "post_reference_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_reference_target_post_id_post_id_fk": {
+          "name": "post_reference_target_post_id_post_id_fk",
+          "tableFrom": "post_reference",
+          "tableTo": "post",
+          "columnsFrom": [
+            "target_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_reference_edge_unique": {
+          "name": "post_reference_edge_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_type",
+            "source_id",
+            "target_post_id",
+            "keyword"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_status_change": {
+      "name": "post_status_change",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_status_template_id": {
+          "name": "to_status_template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by_id": {
+          "name": "changed_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_status_change_post_id_index": {
+          "name": "post_status_change_post_id_index",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_status_change_post_id_post_id_fk": {
+          "name": "post_status_change_post_id_post_id_fk",
+          "tableFrom": "post_status_change",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_status_change_to_status_template_id_status_template_id_fk": {
+          "name": "post_status_change_to_status_template_id_status_template_id_fk",
+          "tableFrom": "post_status_change",
+          "tableTo": "status_template",
+          "columnsFrom": [
+            "to_status_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "post_status_change_changed_by_id_user_id_fk": {
+          "name": "post_status_change_changed_by_id_user_id_fk",
+          "tableFrom": "post_status_change",
+          "tableTo": "user",
+          "columnsFrom": [
+            "changed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_tag": {
+      "name": "post_tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_tag_id_index": {
+          "name": "post_tag_id_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_tag_post_id_index": {
+          "name": "post_tag_post_id_index",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_tag_tag_id_index": {
+          "name": "post_tag_tag_id_index",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_tag_post_id_post_id_fk": {
+          "name": "post_tag_post_id_post_id_fk",
+          "tableFrom": "post_tag",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tag_tag_id_tag_id_fk": {
+          "name": "post_tag_tag_id_tag_id_fk",
+          "tableFrom": "post_tag",
+          "tableTo": "tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_tag_post_tag_unique": {
+          "name": "post_tag_post_tag_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_post_number": {
+          "name": "next_post_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_roadmap": {
+          "name": "show_roadmap",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "show_changelog": {
+          "name": "show_changelog",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "inbound_email_key": {
+          "name": "inbound_email_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_id_index": {
+          "name": "project_id_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_organization_id_idx": {
+          "name": "project_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_inbound_email_key_unique": {
+          "name": "project_inbound_email_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "inbound_email_key"
+          ]
+        },
+        "project_org_slug_idx": {
+          "name": "project_org_slug_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_link": {
+      "name": "project_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_link_id_index": {
+          "name": "project_link_id_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_link_url_project_id_index": {
+          "name": "project_link_url_project_id_index",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_link_project_id_index": {
+          "name": "project_link_project_id_index",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_link_url_index": {
+          "name": "project_link_url_index",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_link_project_id_project_id_fk": {
+          "name": "project_link_project_id_project_id_fk",
+          "tableFrom": "project_link",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_status_config": {
+      "name": "project_status_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_template_id": {
+          "name": "status_template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_color": {
+          "name": "custom_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_description": {
+          "name": "custom_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_status_config_id_index": {
+          "name": "project_status_config_id_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_status_config_project_id_index": {
+          "name": "project_status_config_project_id_index",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_status_config_status_template_id_index": {
+          "name": "project_status_config_status_template_id_index",
+          "columns": [
+            {
+              "expression": "status_template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_status_config_project_id_project_id_fk": {
+          "name": "project_status_config_project_id_project_id_fk",
+          "tableFrom": "project_status_config",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_status_config_status_template_id_status_template_id_fk": {
+          "name": "project_status_config_status_template_id_status_template_id_fk",
+          "tableFrom": "project_status_config",
+          "tableTo": "status_template",
+          "columnsFrom": [
+            "status_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_status_config_projectId_statusTemplateId_unique": {
+          "name": "project_status_config_projectId_statusTemplateId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "status_template_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reaction": {
+      "name": "reaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reaction_id_index": {
+          "name": "reaction_id_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reaction_post_id_index": {
+          "name": "reaction_post_id_index",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reaction_comment_id_index": {
+          "name": "reaction_comment_id_index",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reaction_user_id_index": {
+          "name": "reaction_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reaction_post_id_post_id_fk": {
+          "name": "reaction_post_id_post_id_fk",
+          "tableFrom": "reaction",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reaction_comment_id_comment_id_fk": {
+          "name": "reaction_comment_id_comment_id_fk",
+          "tableFrom": "reaction",
+          "tableTo": "comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reaction_user_id_user_id_fk": {
+          "name": "reaction_user_id_user_id_fk",
+          "tableFrom": "reaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reaction_post_user_emoji_unique": {
+          "name": "reaction_post_user_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "user_id",
+            "emoji"
+          ]
+        },
+        "reaction_comment_user_emoji_unique": {
+          "name": "reaction_comment_user_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "comment_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reaction_target_check": {
+          "name": "reaction_target_check",
+          "value": "(\"reaction\".\"post_id\" IS NOT NULL)::int + (\"reaction\".\"comment_id\" IS NOT NULL)::int = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.signal": {
+      "name": "signal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_content": {
+          "name": "raw_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_tags": {
+          "name": "ai_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "signal_id_index": {
+          "name": "signal_id_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signal_organization_id_index": {
+          "name": "signal_organization_id_index",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signal_project_id_index": {
+          "name": "signal_project_id_index",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signal_user_id_index": {
+          "name": "signal_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signal_post_id_index": {
+          "name": "signal_post_id_index",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signal_status_index": {
+          "name": "signal_status_index",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signal_source_index": {
+          "name": "signal_source_index",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signal_cluster_id_index": {
+          "name": "signal_cluster_id_index",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "signal_project_id_project_id_fk": {
+          "name": "signal_project_id_project_id_fk",
+          "tableFrom": "signal",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "signal_user_id_user_id_fk": {
+          "name": "signal_user_id_user_id_fk",
+          "tableFrom": "signal",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "signal_post_id_post_id_fk": {
+          "name": "signal_post_id_post_id_fk",
+          "tableFrom": "signal",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "signal_cluster_id_signal_cluster_id_fk": {
+          "name": "signal_cluster_id_signal_cluster_id_fk",
+          "tableFrom": "signal",
+          "tableTo": "signal_cluster",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signal_cluster": {
+      "name": "signal_cluster",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "centroid": {
+          "name": "centroid",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "signal_cluster_project_id_index": {
+          "name": "signal_cluster_project_id_index",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "signal_cluster_project_id_project_id_fk": {
+          "name": "signal_cluster_project_id_project_id_fk",
+          "tableFrom": "signal_cluster",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.status_template": {
+      "name": "status_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "show_on_roadmap": {
+          "name": "show_on_roadmap",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_on_board": {
+          "name": "show_on_board",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keyword_role": {
+          "name": "keyword_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "status_template_id_index": {
+          "name": "status_template_id_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "status_template_organization_id_idx": {
+          "name": "status_template_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "status_template_org_name_idx": {
+          "name": "status_template_org_name_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag": {
+      "name": "tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tag_id_index": {
+          "name": "tag_id_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tag_project_id_index": {
+          "name": "tag_project_id_index",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tag_project_id_project_id_fk": {
+          "name": "tag_project_id_project_id_fk",
+          "tableFrom": "tag",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tag_project_name_unique": {
+          "name": "tag_project_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identity_provider_id": {
+          "name": "identity_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_id_index": {
+          "name": "user_id_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_identity_provider_id_index": {
+          "name": "user_identity_provider_id_index",
+          "columns": [
+            {
+              "expression": "identity_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_identityProviderId_unique": {
+          "name": "user_identityProviderId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identity_provider_id"
+          ]
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote": {
+      "name": "vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "vote_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "(case when vote_type = 'up' then 1 else -1 end)",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vote_id_index": {
+          "name": "vote_id_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vote_post_id_index": {
+          "name": "vote_post_id_index",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vote_user_id_index": {
+          "name": "vote_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vote_vote_type_index": {
+          "name": "vote_vote_type_index",
+          "columns": [
+            {
+              "expression": "vote_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vote_post_id_post_id_fk": {
+          "name": "vote_post_id_post_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vote_user_id_user_id_fk": {
+          "name": "vote_user_id_user_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vote_postId_userId_unique": {
+          "name": "vote_postId_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.warden_sync_queue": {
+      "name": "warden_sync_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "warden_sync_queue_next_retry_idx": {
+          "name": "warden_sync_queue_next_retry_idx",
+          "columns": [
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.vote_type": {
+      "name": "vote_type",
+      "schema": "public",
+      "values": [
+        "up",
+        "down"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/generated/drizzle/meta/_journal.json
+++ b/src/generated/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1782445317596,
       "tag": "0028_free_ultragirl",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1782687681304,
+      "tag": "0029_sloppy_toad",
+      "breakpoints": true
     }
   ]
 }

--- a/src/generated/graphql/schema.executable.ts
+++ b/src/generated/graphql/schema.executable.ts
@@ -126,7 +126,7 @@ const spec_postTag = {
     }
   },
   extensions: {
-    oid: "779880",
+    oid: "739621",
     isTableLike: true,
     pg: {
       serviceName: "main",
@@ -204,7 +204,7 @@ const spec_postStatusChange = {
     }
   },
   extensions: {
-    oid: "779968",
+    oid: "745938",
     isTableLike: true,
     pg: {
       serviceName: "main",
@@ -287,7 +287,7 @@ const spec_reaction = {
     }
   },
   extensions: {
-    oid: "779930",
+    oid: "743996",
     isTableLike: true,
     pg: {
       serviceName: "main",
@@ -368,7 +368,7 @@ const spec_tag = {
     }
   },
   extensions: {
-    oid: "779893",
+    oid: "739634",
     isTableLike: true,
     pg: {
       serviceName: "main",
@@ -441,7 +441,7 @@ const notificationPreferenceCodec = recordCodec({
     }
   },
   extensions: {
-    oid: "779996",
+    oid: "746611",
     isTableLike: true,
     pg: {
       serviceName: "main",
@@ -534,7 +534,7 @@ const spec_comment = {
     }
   },
   extensions: {
-    oid: "779389",
+    oid: "270503",
     isTableLike: true,
     pg: {
       serviceName: "main",
@@ -634,7 +634,7 @@ const spec_user = {
     }
   },
   extensions: {
-    oid: "779521",
+    oid: "270635",
     isTableLike: true,
     pg: {
       serviceName: "main",
@@ -742,7 +742,7 @@ const spec_projectStatusConfig = {
     }
   },
   extensions: {
-    oid: "779485",
+    oid: "270599",
     isTableLike: true,
     pg: {
       serviceName: "main",
@@ -834,7 +834,7 @@ const spec_projectLink = {
     }
   },
   extensions: {
-    oid: "779702",
+    oid: "300307",
     isTableLike: true,
     pg: {
       serviceName: "main",
@@ -852,7 +852,7 @@ const voteTypeCodec = enumCodec({
   values: ["up", "down"],
   description: undefined,
   extensions: {
-    oid: "779372",
+    oid: "270486",
     pg: {
       serviceName: "main",
       schemaName: "public",
@@ -941,7 +941,7 @@ const spec_vote = {
     }
   },
   extensions: {
-    oid: "779542",
+    oid: "270656",
     isTableLike: true,
     pg: {
       serviceName: "main",
@@ -1061,7 +1061,7 @@ const spec_postReference = {
     }
   },
   extensions: {
-    oid: "780033",
+    oid: "781347",
     isTableLike: true,
     pg: {
       serviceName: "main",
@@ -1189,7 +1189,7 @@ const spec_attachment = {
     }
   },
   extensions: {
-    oid: "779797",
+    oid: "708031",
     isTableLike: true,
     pg: {
       serviceName: "main",
@@ -1200,6 +1200,221 @@ const spec_attachment = {
   executor: executor
 };
 const attachmentCodec = recordCodec(spec_attachment);
+const wardenSyncQueueIdentifier = sql.identifier("public", "warden_sync_queue");
+const spec_wardenSyncQueue = {
+  name: "wardenSyncQueue",
+  identifier: wardenSyncQueueIdentifier,
+  attributes: {
+    __proto__: null,
+    id: {
+      codec: TYPES.uuid,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        __proto__: null,
+        canSelect: true,
+        canInsert: true,
+        canUpdate: true
+      }
+    },
+    operation: {
+      codec: TYPES.text,
+      notNull: true,
+      extensions: {
+        __proto__: null,
+        canSelect: true,
+        canInsert: true,
+        canUpdate: true
+      }
+    },
+    payload: {
+      codec: TYPES.jsonb,
+      notNull: true,
+      extensions: {
+        __proto__: null,
+        canSelect: true,
+        canInsert: true,
+        canUpdate: true
+      }
+    },
+    attempts: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        __proto__: null,
+        canSelect: true,
+        canInsert: true,
+        canUpdate: true
+      }
+    },
+    max_attempts: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        __proto__: null,
+        canSelect: true,
+        canInsert: true,
+        canUpdate: true
+      }
+    },
+    last_error: {
+      codec: TYPES.text,
+      extensions: {
+        __proto__: null,
+        canSelect: true,
+        canInsert: true,
+        canUpdate: true
+      }
+    },
+    next_retry_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        __proto__: null,
+        canSelect: true,
+        canInsert: true,
+        canUpdate: true
+      }
+    },
+    created_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        __proto__: null,
+        canSelect: true,
+        canInsert: true,
+        canUpdate: true
+      }
+    }
+  },
+  extensions: {
+    oid: "706846",
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "public",
+      name: "warden_sync_queue"
+    }
+  },
+  executor: executor
+};
+const wardenSyncQueueCodec = recordCodec(spec_wardenSyncQueue);
+const signalClusterIdentifier = sql.identifier("public", "signal_cluster");
+const spec_signalCluster_attributes_centroid_codec_vector = {
+  name: "vector",
+  sqlType: sql`vector`,
+  toPg(str) {
+    return str;
+  },
+  fromPg(str) {
+    return str;
+  },
+  executor: null,
+  attributes: void 0
+};
+const spec_signalCluster = {
+  name: "signalCluster",
+  identifier: signalClusterIdentifier,
+  attributes: {
+    __proto__: null,
+    id: {
+      codec: TYPES.uuid,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        __proto__: null,
+        canSelect: true,
+        canInsert: true,
+        canUpdate: true
+      }
+    },
+    project_id: {
+      codec: TYPES.uuid,
+      notNull: true,
+      extensions: {
+        __proto__: null,
+        canSelect: true,
+        canInsert: true,
+        canUpdate: true
+      }
+    },
+    label: {
+      codec: TYPES.text,
+      extensions: {
+        __proto__: null,
+        canSelect: true,
+        canInsert: true,
+        canUpdate: true
+      }
+    },
+    summary: {
+      codec: TYPES.text,
+      extensions: {
+        __proto__: null,
+        canSelect: true,
+        canInsert: true,
+        canUpdate: true
+      }
+    },
+    centroid: {
+      codec: spec_signalCluster_attributes_centroid_codec_vector,
+      extensions: {
+        __proto__: null,
+        canSelect: true,
+        canInsert: true,
+        canUpdate: true
+      }
+    },
+    member_count: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        __proto__: null,
+        canSelect: true,
+        canInsert: true,
+        canUpdate: true
+      }
+    },
+    created_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        __proto__: null,
+        canSelect: true,
+        canInsert: true,
+        canUpdate: true
+      }
+    },
+    updated_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        __proto__: null,
+        canSelect: true,
+        canInsert: true,
+        canUpdate: true
+      }
+    }
+  },
+  extensions: {
+    oid: "731880",
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "public",
+      name: "signal_cluster"
+    }
+  },
+  executor: executor
+};
+const signalClusterCodec = recordCodec(spec_signalCluster);
 const statusTemplateIdentifier = sql.identifier("public", "status_template");
 const spec_statusTemplate = {
   name: "statusTemplate",
@@ -1314,10 +1529,19 @@ const spec_statusTemplate = {
         canInsert: true,
         canUpdate: true
       }
+    },
+    show_on_board: {
+      codec: TYPES.boolean,
+      extensions: {
+        __proto__: null,
+        canSelect: true,
+        canInsert: true,
+        canUpdate: true
+      }
     }
   },
   extensions: {
-    oid: "779502",
+    oid: "270616",
     isTableLike: true,
     pg: {
       serviceName: "main",
@@ -1328,221 +1552,6 @@ const spec_statusTemplate = {
   executor: executor
 };
 const statusTemplateCodec = recordCodec(spec_statusTemplate);
-const wardenSyncQueueIdentifier = sql.identifier("public", "warden_sync_queue");
-const spec_wardenSyncQueue = {
-  name: "wardenSyncQueue",
-  identifier: wardenSyncQueueIdentifier,
-  attributes: {
-    __proto__: null,
-    id: {
-      codec: TYPES.uuid,
-      notNull: true,
-      hasDefault: true,
-      extensions: {
-        __proto__: null,
-        canSelect: true,
-        canInsert: true,
-        canUpdate: true
-      }
-    },
-    operation: {
-      codec: TYPES.text,
-      notNull: true,
-      extensions: {
-        __proto__: null,
-        canSelect: true,
-        canInsert: true,
-        canUpdate: true
-      }
-    },
-    payload: {
-      codec: TYPES.jsonb,
-      notNull: true,
-      extensions: {
-        __proto__: null,
-        canSelect: true,
-        canInsert: true,
-        canUpdate: true
-      }
-    },
-    attempts: {
-      codec: TYPES.int,
-      notNull: true,
-      hasDefault: true,
-      extensions: {
-        __proto__: null,
-        canSelect: true,
-        canInsert: true,
-        canUpdate: true
-      }
-    },
-    max_attempts: {
-      codec: TYPES.int,
-      notNull: true,
-      hasDefault: true,
-      extensions: {
-        __proto__: null,
-        canSelect: true,
-        canInsert: true,
-        canUpdate: true
-      }
-    },
-    last_error: {
-      codec: TYPES.text,
-      extensions: {
-        __proto__: null,
-        canSelect: true,
-        canInsert: true,
-        canUpdate: true
-      }
-    },
-    next_retry_at: {
-      codec: TYPES.timestamptz,
-      notNull: true,
-      hasDefault: true,
-      extensions: {
-        __proto__: null,
-        canSelect: true,
-        canInsert: true,
-        canUpdate: true
-      }
-    },
-    created_at: {
-      codec: TYPES.timestamptz,
-      notNull: true,
-      hasDefault: true,
-      extensions: {
-        __proto__: null,
-        canSelect: true,
-        canInsert: true,
-        canUpdate: true
-      }
-    }
-  },
-  extensions: {
-    oid: "779736",
-    isTableLike: true,
-    pg: {
-      serviceName: "main",
-      schemaName: "public",
-      name: "warden_sync_queue"
-    }
-  },
-  executor: executor
-};
-const wardenSyncQueueCodec = recordCodec(spec_wardenSyncQueue);
-const signalClusterIdentifier = sql.identifier("public", "signal_cluster");
-const spec_signalCluster_attributes_centroid_codec_vector = {
-  name: "vector",
-  sqlType: sql`vector`,
-  toPg(str) {
-    return str;
-  },
-  fromPg(str) {
-    return str;
-  },
-  executor: null,
-  attributes: void 0
-};
-const spec_signalCluster = {
-  name: "signalCluster",
-  identifier: signalClusterIdentifier,
-  attributes: {
-    __proto__: null,
-    id: {
-      codec: TYPES.uuid,
-      notNull: true,
-      hasDefault: true,
-      extensions: {
-        __proto__: null,
-        canSelect: true,
-        canInsert: true,
-        canUpdate: true
-      }
-    },
-    project_id: {
-      codec: TYPES.uuid,
-      notNull: true,
-      extensions: {
-        __proto__: null,
-        canSelect: true,
-        canInsert: true,
-        canUpdate: true
-      }
-    },
-    label: {
-      codec: TYPES.text,
-      extensions: {
-        __proto__: null,
-        canSelect: true,
-        canInsert: true,
-        canUpdate: true
-      }
-    },
-    summary: {
-      codec: TYPES.text,
-      extensions: {
-        __proto__: null,
-        canSelect: true,
-        canInsert: true,
-        canUpdate: true
-      }
-    },
-    centroid: {
-      codec: spec_signalCluster_attributes_centroid_codec_vector,
-      extensions: {
-        __proto__: null,
-        canSelect: true,
-        canInsert: true,
-        canUpdate: true
-      }
-    },
-    member_count: {
-      codec: TYPES.int,
-      notNull: true,
-      hasDefault: true,
-      extensions: {
-        __proto__: null,
-        canSelect: true,
-        canInsert: true,
-        canUpdate: true
-      }
-    },
-    created_at: {
-      codec: TYPES.timestamptz,
-      notNull: true,
-      hasDefault: true,
-      extensions: {
-        __proto__: null,
-        canSelect: true,
-        canInsert: true,
-        canUpdate: true
-      }
-    },
-    updated_at: {
-      codec: TYPES.timestamptz,
-      notNull: true,
-      hasDefault: true,
-      extensions: {
-        __proto__: null,
-        canSelect: true,
-        canInsert: true,
-        canUpdate: true
-      }
-    }
-  },
-  extensions: {
-    oid: "779827",
-    isTableLike: true,
-    pg: {
-      serviceName: "main",
-      schemaName: "public",
-      name: "signal_cluster"
-    }
-  },
-  executor: executor
-};
-const signalClusterCodec = recordCodec(spec_signalCluster);
 const signalIdentifier = sql.identifier("public", "signal");
 const spec_signal = {
   name: "signal",
@@ -1706,7 +1715,7 @@ const spec_signal = {
     }
   },
   extensions: {
-    oid: "779756",
+    oid: "706866",
     isTableLike: true,
     pg: {
       serviceName: "main",
@@ -1895,7 +1904,7 @@ const spec_post = {
     }
   },
   extensions: {
-    oid: "779435",
+    oid: "270549",
     isTableLike: true,
     pg: {
       serviceName: "main",
@@ -2061,7 +2070,7 @@ const spec_project = {
     }
   },
   extensions: {
-    oid: "779452",
+    oid: "270566",
     isTableLike: true,
     pg: {
       serviceName: "main",
@@ -2432,6 +2441,33 @@ const attachment_resourceOptionsConfig = {
   },
   uniques: attachmentUniques
 };
+const warden_sync_queueUniques = [{
+  attributes: ["id"],
+  isPrimary: true
+}];
+const signal_clusterUniques = [{
+  attributes: ["id"],
+  isPrimary: true
+}];
+const signal_cluster_resourceOptionsConfig = {
+  executor: executor,
+  name: "signal_cluster",
+  identifier: "main.public.signal_cluster",
+  from: signalClusterIdentifier,
+  codec: signalClusterCodec,
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "public",
+      name: "signal_cluster"
+    },
+    canSelect: true,
+    canInsert: true,
+    canUpdate: true,
+    canDelete: true
+  },
+  uniques: signal_clusterUniques
+};
 const status_templateUniques = [{
   attributes: ["id"],
   isPrimary: true
@@ -2462,33 +2498,6 @@ const status_template_resourceOptionsConfig = {
     canDelete: true
   },
   uniques: status_templateUniques
-};
-const warden_sync_queueUniques = [{
-  attributes: ["id"],
-  isPrimary: true
-}];
-const signal_clusterUniques = [{
-  attributes: ["id"],
-  isPrimary: true
-}];
-const signal_cluster_resourceOptionsConfig = {
-  executor: executor,
-  name: "signal_cluster",
-  identifier: "main.public.signal_cluster",
-  from: signalClusterIdentifier,
-  codec: signalClusterCodec,
-  extensions: {
-    pg: {
-      serviceName: "main",
-      schemaName: "public",
-      name: "signal_cluster"
-    },
-    canSelect: true,
-    canInsert: true,
-    canUpdate: true,
-    canDelete: true
-  },
-  uniques: signal_clusterUniques
 };
 const signalUniques = [{
   attributes: ["id"],
@@ -2611,11 +2620,11 @@ const registryConfig = {
     voteType: voteTypeCodec,
     postReference: postReferenceCodec,
     attachment: attachmentCodec,
-    statusTemplate: statusTemplateCodec,
     wardenSyncQueue: wardenSyncQueueCodec,
     jsonb: TYPES.jsonb,
     signalCluster: signalClusterCodec,
     vector: spec_signalCluster_attributes_centroid_codec_vector,
+    statusTemplate: statusTemplateCodec,
     signal: signalCodec,
     post: postCodec,
     project: projectCodec,
@@ -2635,7 +2644,6 @@ const registryConfig = {
     vote: vote_resourceOptionsConfig,
     post_reference: post_reference_resourceOptionsConfig,
     attachment: attachment_resourceOptionsConfig,
-    status_template: status_template_resourceOptionsConfig,
     warden_sync_queue: {
       executor: executor,
       name: "warden_sync_queue",
@@ -2656,6 +2664,7 @@ const registryConfig = {
       uniques: warden_sync_queueUniques
     },
     signal_cluster: signal_cluster_resourceOptionsConfig,
+    status_template: status_template_resourceOptionsConfig,
     signal: signal_resourceOptionsConfig,
     project: project_resourceOptionsConfig,
     post: post_resourceOptionsConfig
@@ -4603,19 +4612,6 @@ function AttachmentInput_widthApply(obj, val, info) {
 function AttachmentInput_heightApply(obj, val, info) {
   obj.set("height", bakedInputRuntime(info.schema, info.field.type, val));
 }
-const CreateStatusTemplatePayload_statusTemplateEdgePlan = ($mutation, fieldArgs) => pgMutationPayloadEdge(otherSource_status_templatePgResource, status_templateUniques[0].attributes, $mutation, fieldArgs);
-function StatusTemplateInput_displayNameApply(obj, val, info) {
-  obj.set("display_name", bakedInputRuntime(info.schema, info.field.type, val));
-}
-function StatusTemplateInput_descriptionApply(obj, val, info) {
-  obj.set("description", bakedInputRuntime(info.schema, info.field.type, val));
-}
-function StatusTemplateInput_showOnRoadmapApply(obj, val, info) {
-  obj.set("show_on_roadmap", bakedInputRuntime(info.schema, info.field.type, val));
-}
-function StatusTemplateInput_keywordRoleApply(obj, val, info) {
-  obj.set("keyword_role", bakedInputRuntime(info.schema, info.field.type, val));
-}
 const CreateWardenSyncQueuePayload_wardenSyncQueueEdgePlan = ($mutation, fieldArgs) => pgMutationPayloadEdge(resource_warden_sync_queuePgResource, warden_sync_queueUniques[0].attributes, $mutation, fieldArgs);
 function WardenSyncQueueInput_operationApply(obj, val, info) {
   obj.set("operation", bakedInputRuntime(info.schema, info.field.type, val));
@@ -4644,6 +4640,22 @@ function SignalClusterInput_summaryApply(obj, val, info) {
 }
 function SignalClusterInput_memberCountApply(obj, val, info) {
   obj.set("member_count", bakedInputRuntime(info.schema, info.field.type, val));
+}
+const CreateStatusTemplatePayload_statusTemplateEdgePlan = ($mutation, fieldArgs) => pgMutationPayloadEdge(otherSource_status_templatePgResource, status_templateUniques[0].attributes, $mutation, fieldArgs);
+function StatusTemplateInput_displayNameApply(obj, val, info) {
+  obj.set("display_name", bakedInputRuntime(info.schema, info.field.type, val));
+}
+function StatusTemplateInput_descriptionApply(obj, val, info) {
+  obj.set("description", bakedInputRuntime(info.schema, info.field.type, val));
+}
+function StatusTemplateInput_showOnRoadmapApply(obj, val, info) {
+  obj.set("show_on_roadmap", bakedInputRuntime(info.schema, info.field.type, val));
+}
+function StatusTemplateInput_keywordRoleApply(obj, val, info) {
+  obj.set("keyword_role", bakedInputRuntime(info.schema, info.field.type, val));
+}
+function StatusTemplateInput_showOnBoardApply(obj, val, info) {
+  obj.set("show_on_board", bakedInputRuntime(info.schema, info.field.type, val));
 }
 const CreateProjectPayload_projectEdgePlan = ($mutation, fieldArgs) => pgMutationPayloadEdge(otherSource_projectPgResource, projectUniques[0].attributes, $mutation, fieldArgs);
 function ProjectInput_imageApply(obj, val, info) {
@@ -10443,6 +10455,9 @@ input StatusTemplateFilter {
   """Filter by the object’s \`keywordRole\` field."""
   keywordRole: StringFilter
 
+  """Filter by the object’s \`showOnBoard\` field."""
+  showOnBoard: BooleanFilter
+
   """Filter by the object’s \`posts\` relation."""
   posts: StatusTemplateToManyPostFilter
 
@@ -12004,6 +12019,7 @@ type StatusTemplate {
   updatedAt: Datetime!
   showOnRoadmap: Boolean
   keywordRole: String
+  showOnBoard: Boolean
 
   """Reads and enables pagination through a set of \`Post\`."""
   posts(
@@ -16069,429 +16085,6 @@ enum UserOrderBy {
   POST_STATUS_CHANGES_BY_CHANGED_BY_ID_DISTINCT_COUNT_NOTE_DESC
 }
 
-"""A connection to a list of \`StatusTemplate\` values."""
-type StatusTemplateConnection {
-  """A list of \`StatusTemplate\` objects."""
-  nodes: [StatusTemplate]!
-
-  """
-  A list of edges which contains the \`StatusTemplate\` and cursor to aid in pagination.
-  """
-  edges: [StatusTemplateEdge]!
-
-  """Information to aid in pagination."""
-  pageInfo: PageInfo!
-
-  """The count of *all* \`StatusTemplate\` you could get from the connection."""
-  totalCount: Int!
-
-  """
-  Aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  aggregates: StatusTemplateAggregates
-
-  """
-  Grouped aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  groupedAggregates(
-    """The method to use when grouping \`StatusTemplate\` for these aggregates."""
-    groupBy: [StatusTemplateGroupBy!]!
-
-    """Conditions on the grouped aggregates."""
-    having: StatusTemplateHavingInput
-  ): [StatusTemplateAggregates!]
-}
-
-"""A \`StatusTemplate\` edge in the connection."""
-type StatusTemplateEdge {
-  """A cursor for use in pagination."""
-  cursor: Cursor
-
-  """The \`StatusTemplate\` at the end of the edge."""
-  node: StatusTemplate
-}
-
-type StatusTemplateAggregates {
-  keys: [String]
-
-  """
-  Sum aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  sum: StatusTemplateSumAggregates
-
-  """
-  Distinct count aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  distinctCount: StatusTemplateDistinctCountAggregates
-
-  """
-  Minimum aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  min: StatusTemplateMinAggregates
-
-  """
-  Maximum aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  max: StatusTemplateMaxAggregates
-
-  """
-  Mean average aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  average: StatusTemplateAverageAggregates
-
-  """
-  Sample standard deviation aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  stddevSample: StatusTemplateStddevSampleAggregates
-
-  """
-  Population standard deviation aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  stddevPopulation: StatusTemplateStddevPopulationAggregates
-
-  """
-  Sample variance aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  varianceSample: StatusTemplateVarianceSampleAggregates
-
-  """
-  Population variance aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  variancePopulation: StatusTemplateVariancePopulationAggregates
-}
-
-type StatusTemplateSumAggregates {
-  """Sum of sortOrder across the matching connection"""
-  sortOrder: BigInt!
-}
-
-type StatusTemplateDistinctCountAggregates {
-  """Distinct count of rowId across the matching connection"""
-  rowId: BigInt
-
-  """Distinct count of organizationId across the matching connection"""
-  organizationId: BigInt
-
-  """Distinct count of name across the matching connection"""
-  name: BigInt
-
-  """Distinct count of displayName across the matching connection"""
-  displayName: BigInt
-
-  """Distinct count of color across the matching connection"""
-  color: BigInt
-
-  """Distinct count of description across the matching connection"""
-  description: BigInt
-
-  """Distinct count of sortOrder across the matching connection"""
-  sortOrder: BigInt
-
-  """Distinct count of createdAt across the matching connection"""
-  createdAt: BigInt
-
-  """Distinct count of updatedAt across the matching connection"""
-  updatedAt: BigInt
-
-  """Distinct count of showOnRoadmap across the matching connection"""
-  showOnRoadmap: BigInt
-
-  """Distinct count of keywordRole across the matching connection"""
-  keywordRole: BigInt
-}
-
-type StatusTemplateMinAggregates {
-  """Minimum of sortOrder across the matching connection"""
-  sortOrder: Int
-}
-
-type StatusTemplateMaxAggregates {
-  """Maximum of sortOrder across the matching connection"""
-  sortOrder: Int
-}
-
-type StatusTemplateAverageAggregates {
-  """Mean average of sortOrder across the matching connection"""
-  sortOrder: BigFloat
-}
-
-type StatusTemplateStddevSampleAggregates {
-  """Sample standard deviation of sortOrder across the matching connection"""
-  sortOrder: BigFloat
-}
-
-type StatusTemplateStddevPopulationAggregates {
-  """
-  Population standard deviation of sortOrder across the matching connection
-  """
-  sortOrder: BigFloat
-}
-
-type StatusTemplateVarianceSampleAggregates {
-  """Sample variance of sortOrder across the matching connection"""
-  sortOrder: BigFloat
-}
-
-type StatusTemplateVariancePopulationAggregates {
-  """Population variance of sortOrder across the matching connection"""
-  sortOrder: BigFloat
-}
-
-"""Grouping methods for \`StatusTemplate\` for usage during aggregation."""
-enum StatusTemplateGroupBy {
-  ORGANIZATION_ID
-  NAME
-  DISPLAY_NAME
-  COLOR
-  DESCRIPTION
-  SORT_ORDER
-  CREATED_AT
-  CREATED_AT_TRUNCATED_TO_HOUR
-  CREATED_AT_TRUNCATED_TO_DAY
-  UPDATED_AT
-  UPDATED_AT_TRUNCATED_TO_HOUR
-  UPDATED_AT_TRUNCATED_TO_DAY
-  SHOW_ON_ROADMAP
-  KEYWORD_ROLE
-}
-
-"""Conditions for \`StatusTemplate\` aggregates."""
-input StatusTemplateHavingInput {
-  AND: [StatusTemplateHavingInput!]
-  OR: [StatusTemplateHavingInput!]
-  sum: StatusTemplateHavingSumInput
-  distinctCount: StatusTemplateHavingDistinctCountInput
-  min: StatusTemplateHavingMinInput
-  max: StatusTemplateHavingMaxInput
-  average: StatusTemplateHavingAverageInput
-  stddevSample: StatusTemplateHavingStddevSampleInput
-  stddevPopulation: StatusTemplateHavingStddevPopulationInput
-  varianceSample: StatusTemplateHavingVarianceSampleInput
-  variancePopulation: StatusTemplateHavingVariancePopulationInput
-}
-
-input StatusTemplateHavingSumInput {
-  sortOrder: HavingIntFilter
-  createdAt: HavingDatetimeFilter
-  updatedAt: HavingDatetimeFilter
-}
-
-input StatusTemplateHavingDistinctCountInput {
-  sortOrder: HavingIntFilter
-  createdAt: HavingDatetimeFilter
-  updatedAt: HavingDatetimeFilter
-}
-
-input StatusTemplateHavingMinInput {
-  sortOrder: HavingIntFilter
-  createdAt: HavingDatetimeFilter
-  updatedAt: HavingDatetimeFilter
-}
-
-input StatusTemplateHavingMaxInput {
-  sortOrder: HavingIntFilter
-  createdAt: HavingDatetimeFilter
-  updatedAt: HavingDatetimeFilter
-}
-
-input StatusTemplateHavingAverageInput {
-  sortOrder: HavingIntFilter
-  createdAt: HavingDatetimeFilter
-  updatedAt: HavingDatetimeFilter
-}
-
-input StatusTemplateHavingStddevSampleInput {
-  sortOrder: HavingIntFilter
-  createdAt: HavingDatetimeFilter
-  updatedAt: HavingDatetimeFilter
-}
-
-input StatusTemplateHavingStddevPopulationInput {
-  sortOrder: HavingIntFilter
-  createdAt: HavingDatetimeFilter
-  updatedAt: HavingDatetimeFilter
-}
-
-input StatusTemplateHavingVarianceSampleInput {
-  sortOrder: HavingIntFilter
-  createdAt: HavingDatetimeFilter
-  updatedAt: HavingDatetimeFilter
-}
-
-input StatusTemplateHavingVariancePopulationInput {
-  sortOrder: HavingIntFilter
-  createdAt: HavingDatetimeFilter
-  updatedAt: HavingDatetimeFilter
-}
-
-"""
-A condition to be used against \`StatusTemplate\` object types. All fields are
-tested for equality and combined with a logical ‘and.’
-"""
-input StatusTemplateCondition {
-  """Checks for equality with the object’s \`rowId\` field."""
-  rowId: UUID
-
-  """Checks for equality with the object’s \`organizationId\` field."""
-  organizationId: UUID
-
-  """Checks for equality with the object’s \`name\` field."""
-  name: String
-
-  """Checks for equality with the object’s \`displayName\` field."""
-  displayName: String
-
-  """Checks for equality with the object’s \`color\` field."""
-  color: String
-
-  """Checks for equality with the object’s \`description\` field."""
-  description: String
-
-  """Checks for equality with the object’s \`sortOrder\` field."""
-  sortOrder: Int
-
-  """Checks for equality with the object’s \`createdAt\` field."""
-  createdAt: Datetime
-
-  """Checks for equality with the object’s \`updatedAt\` field."""
-  updatedAt: Datetime
-
-  """Checks for equality with the object’s \`showOnRoadmap\` field."""
-  showOnRoadmap: Boolean
-
-  """Checks for equality with the object’s \`keywordRole\` field."""
-  keywordRole: String
-}
-
-"""Methods to use when ordering \`StatusTemplate\`."""
-enum StatusTemplateOrderBy {
-  NATURAL
-  PRIMARY_KEY_ASC
-  PRIMARY_KEY_DESC
-  ROW_ID_ASC
-  ROW_ID_DESC
-  ORGANIZATION_ID_ASC
-  ORGANIZATION_ID_DESC
-  NAME_ASC
-  NAME_DESC
-  DISPLAY_NAME_ASC
-  DISPLAY_NAME_DESC
-  COLOR_ASC
-  COLOR_DESC
-  DESCRIPTION_ASC
-  DESCRIPTION_DESC
-  SORT_ORDER_ASC
-  SORT_ORDER_DESC
-  CREATED_AT_ASC
-  CREATED_AT_DESC
-  UPDATED_AT_ASC
-  UPDATED_AT_DESC
-  SHOW_ON_ROADMAP_ASC
-  SHOW_ON_ROADMAP_DESC
-  KEYWORD_ROLE_ASC
-  KEYWORD_ROLE_DESC
-  POSTS_COUNT_ASC
-  POSTS_COUNT_DESC
-  POSTS_SUM_NUMBER_ASC
-  POSTS_SUM_NUMBER_DESC
-  POSTS_DISTINCT_COUNT_ROW_ID_ASC
-  POSTS_DISTINCT_COUNT_ROW_ID_DESC
-  POSTS_DISTINCT_COUNT_TITLE_ASC
-  POSTS_DISTINCT_COUNT_TITLE_DESC
-  POSTS_DISTINCT_COUNT_DESCRIPTION_ASC
-  POSTS_DISTINCT_COUNT_DESCRIPTION_DESC
-  POSTS_DISTINCT_COUNT_PROJECT_ID_ASC
-  POSTS_DISTINCT_COUNT_PROJECT_ID_DESC
-  POSTS_DISTINCT_COUNT_USER_ID_ASC
-  POSTS_DISTINCT_COUNT_USER_ID_DESC
-  POSTS_DISTINCT_COUNT_STATUS_TEMPLATE_ID_ASC
-  POSTS_DISTINCT_COUNT_STATUS_TEMPLATE_ID_DESC
-  POSTS_DISTINCT_COUNT_STATUS_UPDATED_AT_ASC
-  POSTS_DISTINCT_COUNT_STATUS_UPDATED_AT_DESC
-  POSTS_DISTINCT_COUNT_CREATED_AT_ASC
-  POSTS_DISTINCT_COUNT_CREATED_AT_DESC
-  POSTS_DISTINCT_COUNT_UPDATED_AT_ASC
-  POSTS_DISTINCT_COUNT_UPDATED_AT_DESC
-  POSTS_DISTINCT_COUNT_NUMBER_ASC
-  POSTS_DISTINCT_COUNT_NUMBER_DESC
-  POSTS_DISTINCT_COUNT_SOURCE_ASC
-  POSTS_DISTINCT_COUNT_SOURCE_DESC
-  POSTS_DISTINCT_COUNT_SENTIMENT_ASC
-  POSTS_DISTINCT_COUNT_SENTIMENT_DESC
-  POSTS_DISTINCT_COUNT_AI_TAGS_ASC
-  POSTS_DISTINCT_COUNT_AI_TAGS_DESC
-  POSTS_DISTINCT_COUNT_DUPLICATE_OF_ID_ASC
-  POSTS_DISTINCT_COUNT_DUPLICATE_OF_ID_DESC
-  POSTS_DISTINCT_COUNT_CLUSTER_ID_ASC
-  POSTS_DISTINCT_COUNT_CLUSTER_ID_DESC
-  POSTS_DISTINCT_COUNT_SHIPPED_AT_ASC
-  POSTS_DISTINCT_COUNT_SHIPPED_AT_DESC
-  POSTS_MIN_NUMBER_ASC
-  POSTS_MIN_NUMBER_DESC
-  POSTS_MAX_NUMBER_ASC
-  POSTS_MAX_NUMBER_DESC
-  POSTS_AVERAGE_NUMBER_ASC
-  POSTS_AVERAGE_NUMBER_DESC
-  POSTS_STDDEV_SAMPLE_NUMBER_ASC
-  POSTS_STDDEV_SAMPLE_NUMBER_DESC
-  POSTS_STDDEV_POPULATION_NUMBER_ASC
-  POSTS_STDDEV_POPULATION_NUMBER_DESC
-  POSTS_VARIANCE_SAMPLE_NUMBER_ASC
-  POSTS_VARIANCE_SAMPLE_NUMBER_DESC
-  POSTS_VARIANCE_POPULATION_NUMBER_ASC
-  POSTS_VARIANCE_POPULATION_NUMBER_DESC
-  PROJECT_STATUS_CONFIGS_COUNT_ASC
-  PROJECT_STATUS_CONFIGS_COUNT_DESC
-  PROJECT_STATUS_CONFIGS_SUM_SORT_ORDER_ASC
-  PROJECT_STATUS_CONFIGS_SUM_SORT_ORDER_DESC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_ROW_ID_ASC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_ROW_ID_DESC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_PROJECT_ID_ASC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_PROJECT_ID_DESC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_STATUS_TEMPLATE_ID_ASC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_STATUS_TEMPLATE_ID_DESC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CUSTOM_COLOR_ASC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CUSTOM_COLOR_DESC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CUSTOM_DESCRIPTION_ASC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CUSTOM_DESCRIPTION_DESC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_IS_ENABLED_ASC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_IS_ENABLED_DESC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_IS_DEFAULT_ASC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_IS_DEFAULT_DESC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_SORT_ORDER_ASC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_SORT_ORDER_DESC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CREATED_AT_ASC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CREATED_AT_DESC
-  PROJECT_STATUS_CONFIGS_MIN_SORT_ORDER_ASC
-  PROJECT_STATUS_CONFIGS_MIN_SORT_ORDER_DESC
-  PROJECT_STATUS_CONFIGS_MAX_SORT_ORDER_ASC
-  PROJECT_STATUS_CONFIGS_MAX_SORT_ORDER_DESC
-  PROJECT_STATUS_CONFIGS_AVERAGE_SORT_ORDER_ASC
-  PROJECT_STATUS_CONFIGS_AVERAGE_SORT_ORDER_DESC
-  PROJECT_STATUS_CONFIGS_STDDEV_SAMPLE_SORT_ORDER_ASC
-  PROJECT_STATUS_CONFIGS_STDDEV_SAMPLE_SORT_ORDER_DESC
-  PROJECT_STATUS_CONFIGS_STDDEV_POPULATION_SORT_ORDER_ASC
-  PROJECT_STATUS_CONFIGS_STDDEV_POPULATION_SORT_ORDER_DESC
-  PROJECT_STATUS_CONFIGS_VARIANCE_SAMPLE_SORT_ORDER_ASC
-  PROJECT_STATUS_CONFIGS_VARIANCE_SAMPLE_SORT_ORDER_DESC
-  PROJECT_STATUS_CONFIGS_VARIANCE_POPULATION_SORT_ORDER_ASC
-  PROJECT_STATUS_CONFIGS_VARIANCE_POPULATION_SORT_ORDER_DESC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_COUNT_ASC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_COUNT_DESC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_ROW_ID_ASC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_ROW_ID_DESC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_POST_ID_ASC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_POST_ID_DESC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_TO_STATUS_TEMPLATE_ID_ASC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_TO_STATUS_TEMPLATE_ID_DESC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_CHANGED_BY_ID_ASC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_CHANGED_BY_ID_DESC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_CREATED_AT_ASC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_CREATED_AT_DESC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_NOTE_ASC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_NOTE_DESC
-}
-
 """A connection to a list of \`WardenSyncQueue\` values."""
 type WardenSyncQueueConnection {
   """A list of \`WardenSyncQueue\` objects."""
@@ -16857,6 +16450,438 @@ enum WardenSyncQueueOrderBy {
   NEXT_RETRY_AT_DESC
   CREATED_AT_ASC
   CREATED_AT_DESC
+}
+
+"""A connection to a list of \`StatusTemplate\` values."""
+type StatusTemplateConnection {
+  """A list of \`StatusTemplate\` objects."""
+  nodes: [StatusTemplate]!
+
+  """
+  A list of edges which contains the \`StatusTemplate\` and cursor to aid in pagination.
+  """
+  edges: [StatusTemplateEdge]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`StatusTemplate\` you could get from the connection."""
+  totalCount: Int!
+
+  """
+  Aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  aggregates: StatusTemplateAggregates
+
+  """
+  Grouped aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  groupedAggregates(
+    """The method to use when grouping \`StatusTemplate\` for these aggregates."""
+    groupBy: [StatusTemplateGroupBy!]!
+
+    """Conditions on the grouped aggregates."""
+    having: StatusTemplateHavingInput
+  ): [StatusTemplateAggregates!]
+}
+
+"""A \`StatusTemplate\` edge in the connection."""
+type StatusTemplateEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`StatusTemplate\` at the end of the edge."""
+  node: StatusTemplate
+}
+
+type StatusTemplateAggregates {
+  keys: [String]
+
+  """
+  Sum aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  sum: StatusTemplateSumAggregates
+
+  """
+  Distinct count aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  distinctCount: StatusTemplateDistinctCountAggregates
+
+  """
+  Minimum aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  min: StatusTemplateMinAggregates
+
+  """
+  Maximum aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  max: StatusTemplateMaxAggregates
+
+  """
+  Mean average aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  average: StatusTemplateAverageAggregates
+
+  """
+  Sample standard deviation aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  stddevSample: StatusTemplateStddevSampleAggregates
+
+  """
+  Population standard deviation aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  stddevPopulation: StatusTemplateStddevPopulationAggregates
+
+  """
+  Sample variance aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  varianceSample: StatusTemplateVarianceSampleAggregates
+
+  """
+  Population variance aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  variancePopulation: StatusTemplateVariancePopulationAggregates
+}
+
+type StatusTemplateSumAggregates {
+  """Sum of sortOrder across the matching connection"""
+  sortOrder: BigInt!
+}
+
+type StatusTemplateDistinctCountAggregates {
+  """Distinct count of rowId across the matching connection"""
+  rowId: BigInt
+
+  """Distinct count of organizationId across the matching connection"""
+  organizationId: BigInt
+
+  """Distinct count of name across the matching connection"""
+  name: BigInt
+
+  """Distinct count of displayName across the matching connection"""
+  displayName: BigInt
+
+  """Distinct count of color across the matching connection"""
+  color: BigInt
+
+  """Distinct count of description across the matching connection"""
+  description: BigInt
+
+  """Distinct count of sortOrder across the matching connection"""
+  sortOrder: BigInt
+
+  """Distinct count of createdAt across the matching connection"""
+  createdAt: BigInt
+
+  """Distinct count of updatedAt across the matching connection"""
+  updatedAt: BigInt
+
+  """Distinct count of showOnRoadmap across the matching connection"""
+  showOnRoadmap: BigInt
+
+  """Distinct count of keywordRole across the matching connection"""
+  keywordRole: BigInt
+
+  """Distinct count of showOnBoard across the matching connection"""
+  showOnBoard: BigInt
+}
+
+type StatusTemplateMinAggregates {
+  """Minimum of sortOrder across the matching connection"""
+  sortOrder: Int
+}
+
+type StatusTemplateMaxAggregates {
+  """Maximum of sortOrder across the matching connection"""
+  sortOrder: Int
+}
+
+type StatusTemplateAverageAggregates {
+  """Mean average of sortOrder across the matching connection"""
+  sortOrder: BigFloat
+}
+
+type StatusTemplateStddevSampleAggregates {
+  """Sample standard deviation of sortOrder across the matching connection"""
+  sortOrder: BigFloat
+}
+
+type StatusTemplateStddevPopulationAggregates {
+  """
+  Population standard deviation of sortOrder across the matching connection
+  """
+  sortOrder: BigFloat
+}
+
+type StatusTemplateVarianceSampleAggregates {
+  """Sample variance of sortOrder across the matching connection"""
+  sortOrder: BigFloat
+}
+
+type StatusTemplateVariancePopulationAggregates {
+  """Population variance of sortOrder across the matching connection"""
+  sortOrder: BigFloat
+}
+
+"""Grouping methods for \`StatusTemplate\` for usage during aggregation."""
+enum StatusTemplateGroupBy {
+  ORGANIZATION_ID
+  NAME
+  DISPLAY_NAME
+  COLOR
+  DESCRIPTION
+  SORT_ORDER
+  CREATED_AT
+  CREATED_AT_TRUNCATED_TO_HOUR
+  CREATED_AT_TRUNCATED_TO_DAY
+  UPDATED_AT
+  UPDATED_AT_TRUNCATED_TO_HOUR
+  UPDATED_AT_TRUNCATED_TO_DAY
+  SHOW_ON_ROADMAP
+  KEYWORD_ROLE
+  SHOW_ON_BOARD
+}
+
+"""Conditions for \`StatusTemplate\` aggregates."""
+input StatusTemplateHavingInput {
+  AND: [StatusTemplateHavingInput!]
+  OR: [StatusTemplateHavingInput!]
+  sum: StatusTemplateHavingSumInput
+  distinctCount: StatusTemplateHavingDistinctCountInput
+  min: StatusTemplateHavingMinInput
+  max: StatusTemplateHavingMaxInput
+  average: StatusTemplateHavingAverageInput
+  stddevSample: StatusTemplateHavingStddevSampleInput
+  stddevPopulation: StatusTemplateHavingStddevPopulationInput
+  varianceSample: StatusTemplateHavingVarianceSampleInput
+  variancePopulation: StatusTemplateHavingVariancePopulationInput
+}
+
+input StatusTemplateHavingSumInput {
+  sortOrder: HavingIntFilter
+  createdAt: HavingDatetimeFilter
+  updatedAt: HavingDatetimeFilter
+}
+
+input StatusTemplateHavingDistinctCountInput {
+  sortOrder: HavingIntFilter
+  createdAt: HavingDatetimeFilter
+  updatedAt: HavingDatetimeFilter
+}
+
+input StatusTemplateHavingMinInput {
+  sortOrder: HavingIntFilter
+  createdAt: HavingDatetimeFilter
+  updatedAt: HavingDatetimeFilter
+}
+
+input StatusTemplateHavingMaxInput {
+  sortOrder: HavingIntFilter
+  createdAt: HavingDatetimeFilter
+  updatedAt: HavingDatetimeFilter
+}
+
+input StatusTemplateHavingAverageInput {
+  sortOrder: HavingIntFilter
+  createdAt: HavingDatetimeFilter
+  updatedAt: HavingDatetimeFilter
+}
+
+input StatusTemplateHavingStddevSampleInput {
+  sortOrder: HavingIntFilter
+  createdAt: HavingDatetimeFilter
+  updatedAt: HavingDatetimeFilter
+}
+
+input StatusTemplateHavingStddevPopulationInput {
+  sortOrder: HavingIntFilter
+  createdAt: HavingDatetimeFilter
+  updatedAt: HavingDatetimeFilter
+}
+
+input StatusTemplateHavingVarianceSampleInput {
+  sortOrder: HavingIntFilter
+  createdAt: HavingDatetimeFilter
+  updatedAt: HavingDatetimeFilter
+}
+
+input StatusTemplateHavingVariancePopulationInput {
+  sortOrder: HavingIntFilter
+  createdAt: HavingDatetimeFilter
+  updatedAt: HavingDatetimeFilter
+}
+
+"""
+A condition to be used against \`StatusTemplate\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input StatusTemplateCondition {
+  """Checks for equality with the object’s \`rowId\` field."""
+  rowId: UUID
+
+  """Checks for equality with the object’s \`organizationId\` field."""
+  organizationId: UUID
+
+  """Checks for equality with the object’s \`name\` field."""
+  name: String
+
+  """Checks for equality with the object’s \`displayName\` field."""
+  displayName: String
+
+  """Checks for equality with the object’s \`color\` field."""
+  color: String
+
+  """Checks for equality with the object’s \`description\` field."""
+  description: String
+
+  """Checks for equality with the object’s \`sortOrder\` field."""
+  sortOrder: Int
+
+  """Checks for equality with the object’s \`createdAt\` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s \`updatedAt\` field."""
+  updatedAt: Datetime
+
+  """Checks for equality with the object’s \`showOnRoadmap\` field."""
+  showOnRoadmap: Boolean
+
+  """Checks for equality with the object’s \`keywordRole\` field."""
+  keywordRole: String
+
+  """Checks for equality with the object’s \`showOnBoard\` field."""
+  showOnBoard: Boolean
+}
+
+"""Methods to use when ordering \`StatusTemplate\`."""
+enum StatusTemplateOrderBy {
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  ROW_ID_ASC
+  ROW_ID_DESC
+  ORGANIZATION_ID_ASC
+  ORGANIZATION_ID_DESC
+  NAME_ASC
+  NAME_DESC
+  DISPLAY_NAME_ASC
+  DISPLAY_NAME_DESC
+  COLOR_ASC
+  COLOR_DESC
+  DESCRIPTION_ASC
+  DESCRIPTION_DESC
+  SORT_ORDER_ASC
+  SORT_ORDER_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  SHOW_ON_ROADMAP_ASC
+  SHOW_ON_ROADMAP_DESC
+  KEYWORD_ROLE_ASC
+  KEYWORD_ROLE_DESC
+  SHOW_ON_BOARD_ASC
+  SHOW_ON_BOARD_DESC
+  POSTS_COUNT_ASC
+  POSTS_COUNT_DESC
+  POSTS_SUM_NUMBER_ASC
+  POSTS_SUM_NUMBER_DESC
+  POSTS_DISTINCT_COUNT_ROW_ID_ASC
+  POSTS_DISTINCT_COUNT_ROW_ID_DESC
+  POSTS_DISTINCT_COUNT_TITLE_ASC
+  POSTS_DISTINCT_COUNT_TITLE_DESC
+  POSTS_DISTINCT_COUNT_DESCRIPTION_ASC
+  POSTS_DISTINCT_COUNT_DESCRIPTION_DESC
+  POSTS_DISTINCT_COUNT_PROJECT_ID_ASC
+  POSTS_DISTINCT_COUNT_PROJECT_ID_DESC
+  POSTS_DISTINCT_COUNT_USER_ID_ASC
+  POSTS_DISTINCT_COUNT_USER_ID_DESC
+  POSTS_DISTINCT_COUNT_STATUS_TEMPLATE_ID_ASC
+  POSTS_DISTINCT_COUNT_STATUS_TEMPLATE_ID_DESC
+  POSTS_DISTINCT_COUNT_STATUS_UPDATED_AT_ASC
+  POSTS_DISTINCT_COUNT_STATUS_UPDATED_AT_DESC
+  POSTS_DISTINCT_COUNT_CREATED_AT_ASC
+  POSTS_DISTINCT_COUNT_CREATED_AT_DESC
+  POSTS_DISTINCT_COUNT_UPDATED_AT_ASC
+  POSTS_DISTINCT_COUNT_UPDATED_AT_DESC
+  POSTS_DISTINCT_COUNT_NUMBER_ASC
+  POSTS_DISTINCT_COUNT_NUMBER_DESC
+  POSTS_DISTINCT_COUNT_SOURCE_ASC
+  POSTS_DISTINCT_COUNT_SOURCE_DESC
+  POSTS_DISTINCT_COUNT_SENTIMENT_ASC
+  POSTS_DISTINCT_COUNT_SENTIMENT_DESC
+  POSTS_DISTINCT_COUNT_AI_TAGS_ASC
+  POSTS_DISTINCT_COUNT_AI_TAGS_DESC
+  POSTS_DISTINCT_COUNT_DUPLICATE_OF_ID_ASC
+  POSTS_DISTINCT_COUNT_DUPLICATE_OF_ID_DESC
+  POSTS_DISTINCT_COUNT_CLUSTER_ID_ASC
+  POSTS_DISTINCT_COUNT_CLUSTER_ID_DESC
+  POSTS_DISTINCT_COUNT_SHIPPED_AT_ASC
+  POSTS_DISTINCT_COUNT_SHIPPED_AT_DESC
+  POSTS_MIN_NUMBER_ASC
+  POSTS_MIN_NUMBER_DESC
+  POSTS_MAX_NUMBER_ASC
+  POSTS_MAX_NUMBER_DESC
+  POSTS_AVERAGE_NUMBER_ASC
+  POSTS_AVERAGE_NUMBER_DESC
+  POSTS_STDDEV_SAMPLE_NUMBER_ASC
+  POSTS_STDDEV_SAMPLE_NUMBER_DESC
+  POSTS_STDDEV_POPULATION_NUMBER_ASC
+  POSTS_STDDEV_POPULATION_NUMBER_DESC
+  POSTS_VARIANCE_SAMPLE_NUMBER_ASC
+  POSTS_VARIANCE_SAMPLE_NUMBER_DESC
+  POSTS_VARIANCE_POPULATION_NUMBER_ASC
+  POSTS_VARIANCE_POPULATION_NUMBER_DESC
+  PROJECT_STATUS_CONFIGS_COUNT_ASC
+  PROJECT_STATUS_CONFIGS_COUNT_DESC
+  PROJECT_STATUS_CONFIGS_SUM_SORT_ORDER_ASC
+  PROJECT_STATUS_CONFIGS_SUM_SORT_ORDER_DESC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_ROW_ID_ASC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_ROW_ID_DESC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_PROJECT_ID_ASC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_PROJECT_ID_DESC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_STATUS_TEMPLATE_ID_ASC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_STATUS_TEMPLATE_ID_DESC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CUSTOM_COLOR_ASC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CUSTOM_COLOR_DESC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CUSTOM_DESCRIPTION_ASC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CUSTOM_DESCRIPTION_DESC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_IS_ENABLED_ASC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_IS_ENABLED_DESC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_IS_DEFAULT_ASC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_IS_DEFAULT_DESC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_SORT_ORDER_ASC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_SORT_ORDER_DESC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CREATED_AT_ASC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CREATED_AT_DESC
+  PROJECT_STATUS_CONFIGS_MIN_SORT_ORDER_ASC
+  PROJECT_STATUS_CONFIGS_MIN_SORT_ORDER_DESC
+  PROJECT_STATUS_CONFIGS_MAX_SORT_ORDER_ASC
+  PROJECT_STATUS_CONFIGS_MAX_SORT_ORDER_DESC
+  PROJECT_STATUS_CONFIGS_AVERAGE_SORT_ORDER_ASC
+  PROJECT_STATUS_CONFIGS_AVERAGE_SORT_ORDER_DESC
+  PROJECT_STATUS_CONFIGS_STDDEV_SAMPLE_SORT_ORDER_ASC
+  PROJECT_STATUS_CONFIGS_STDDEV_SAMPLE_SORT_ORDER_DESC
+  PROJECT_STATUS_CONFIGS_STDDEV_POPULATION_SORT_ORDER_ASC
+  PROJECT_STATUS_CONFIGS_STDDEV_POPULATION_SORT_ORDER_DESC
+  PROJECT_STATUS_CONFIGS_VARIANCE_SAMPLE_SORT_ORDER_ASC
+  PROJECT_STATUS_CONFIGS_VARIANCE_SAMPLE_SORT_ORDER_DESC
+  PROJECT_STATUS_CONFIGS_VARIANCE_POPULATION_SORT_ORDER_ASC
+  PROJECT_STATUS_CONFIGS_VARIANCE_POPULATION_SORT_ORDER_DESC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_COUNT_ASC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_COUNT_DESC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_ROW_ID_ASC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_ROW_ID_DESC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_POST_ID_ASC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_POST_ID_DESC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_TO_STATUS_TEMPLATE_ID_ASC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_TO_STATUS_TEMPLATE_ID_DESC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_CHANGED_BY_ID_ASC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_CHANGED_BY_ID_DESC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_CREATED_AT_ASC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_CREATED_AT_DESC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_NOTE_ASC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_NOTE_DESC
 }
 
 """A connection to a list of \`Project\` values."""
@@ -17870,56 +17895,6 @@ input AttachmentInput {
   createdAt: Datetime
 }
 
-"""The output of our create \`StatusTemplate\` mutation."""
-type CreateStatusTemplatePayload {
-  """
-  The exact same \`clientMutationId\` that was provided in the mutation input,
-  unchanged and unused. May be used by a client to track mutations.
-  """
-  clientMutationId: String
-
-  """The \`StatusTemplate\` that was created by this mutation."""
-  statusTemplate: StatusTemplate
-
-  """
-  Our root query field type. Allows us to run any query from our mutation payload.
-  """
-  query: Query
-
-  """An edge for our \`StatusTemplate\`. May be used by Relay 1."""
-  statusTemplateEdge(
-    """The method to use when ordering \`StatusTemplate\`."""
-    orderBy: [StatusTemplateOrderBy!]! = [PRIMARY_KEY_ASC]
-  ): StatusTemplateEdge
-}
-
-"""All input for the create \`StatusTemplate\` mutation."""
-input CreateStatusTemplateInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-
-  """The \`StatusTemplate\` to be created by this mutation."""
-  statusTemplate: StatusTemplateInput!
-}
-
-"""An input for mutations affecting \`StatusTemplate\`"""
-input StatusTemplateInput {
-  rowId: UUID
-  organizationId: UUID!
-  name: String!
-  displayName: String!
-  color: String
-  description: String
-  sortOrder: Int
-  createdAt: Datetime
-  updatedAt: Datetime
-  showOnRoadmap: Boolean
-  keywordRole: String
-}
-
 """The output of our create \`WardenSyncQueue\` mutation."""
 type CreateWardenSyncQueuePayload {
   """
@@ -18011,6 +17986,57 @@ input SignalClusterInput {
   memberCount: Int
   createdAt: Datetime
   updatedAt: Datetime
+}
+
+"""The output of our create \`StatusTemplate\` mutation."""
+type CreateStatusTemplatePayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`StatusTemplate\` that was created by this mutation."""
+  statusTemplate: StatusTemplate
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`StatusTemplate\`. May be used by Relay 1."""
+  statusTemplateEdge(
+    """The method to use when ordering \`StatusTemplate\`."""
+    orderBy: [StatusTemplateOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): StatusTemplateEdge
+}
+
+"""All input for the create \`StatusTemplate\` mutation."""
+input CreateStatusTemplateInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The \`StatusTemplate\` to be created by this mutation."""
+  statusTemplate: StatusTemplateInput!
+}
+
+"""An input for mutations affecting \`StatusTemplate\`"""
+input StatusTemplateInput {
+  rowId: UUID
+  organizationId: UUID!
+  name: String!
+  displayName: String!
+  color: String
+  description: String
+  sortOrder: Int
+  createdAt: Datetime
+  updatedAt: Datetime
+  showOnRoadmap: Boolean
+  keywordRole: String
+  showOnBoard: Boolean
 }
 
 """The output of our create \`Project\` mutation."""
@@ -18628,61 +18654,6 @@ input AttachmentPatch {
   createdAt: Datetime
 }
 
-"""The output of our update \`StatusTemplate\` mutation."""
-type UpdateStatusTemplatePayload {
-  """
-  The exact same \`clientMutationId\` that was provided in the mutation input,
-  unchanged and unused. May be used by a client to track mutations.
-  """
-  clientMutationId: String
-
-  """The \`StatusTemplate\` that was updated by this mutation."""
-  statusTemplate: StatusTemplate
-
-  """
-  Our root query field type. Allows us to run any query from our mutation payload.
-  """
-  query: Query
-
-  """An edge for our \`StatusTemplate\`. May be used by Relay 1."""
-  statusTemplateEdge(
-    """The method to use when ordering \`StatusTemplate\`."""
-    orderBy: [StatusTemplateOrderBy!]! = [PRIMARY_KEY_ASC]
-  ): StatusTemplateEdge
-}
-
-"""All input for the \`updateStatusTemplate\` mutation."""
-input UpdateStatusTemplateInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-  rowId: UUID!
-
-  """
-  An object where the defined keys will be set on the \`StatusTemplate\` being updated.
-  """
-  patch: StatusTemplatePatch!
-}
-
-"""
-Represents an update to a \`StatusTemplate\`. Fields that are set will be updated.
-"""
-input StatusTemplatePatch {
-  rowId: UUID
-  organizationId: UUID
-  name: String
-  displayName: String
-  color: String
-  description: String
-  sortOrder: Int
-  createdAt: Datetime
-  updatedAt: Datetime
-  showOnRoadmap: Boolean
-  keywordRole: String
-}
-
 """The output of our update \`WardenSyncQueue\` mutation."""
 type UpdateWardenSyncQueuePayload {
   """
@@ -18784,6 +18755,62 @@ input SignalClusterPatch {
   memberCount: Int
   createdAt: Datetime
   updatedAt: Datetime
+}
+
+"""The output of our update \`StatusTemplate\` mutation."""
+type UpdateStatusTemplatePayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`StatusTemplate\` that was updated by this mutation."""
+  statusTemplate: StatusTemplate
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`StatusTemplate\`. May be used by Relay 1."""
+  statusTemplateEdge(
+    """The method to use when ordering \`StatusTemplate\`."""
+    orderBy: [StatusTemplateOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): StatusTemplateEdge
+}
+
+"""All input for the \`updateStatusTemplate\` mutation."""
+input UpdateStatusTemplateInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  rowId: UUID!
+
+  """
+  An object where the defined keys will be set on the \`StatusTemplate\` being updated.
+  """
+  patch: StatusTemplatePatch!
+}
+
+"""
+Represents an update to a \`StatusTemplate\`. Fields that are set will be updated.
+"""
+input StatusTemplatePatch {
+  rowId: UUID
+  organizationId: UUID
+  name: String
+  displayName: String
+  color: String
+  description: String
+  sortOrder: Int
+  createdAt: Datetime
+  updatedAt: Datetime
+  showOnRoadmap: Boolean
+  keywordRole: String
+  showOnBoard: Boolean
 }
 
 """The output of our update \`Project\` mutation."""
@@ -19230,39 +19257,6 @@ input DeleteAttachmentInput {
   rowId: UUID!
 }
 
-"""The output of our delete \`StatusTemplate\` mutation."""
-type DeleteStatusTemplatePayload {
-  """
-  The exact same \`clientMutationId\` that was provided in the mutation input,
-  unchanged and unused. May be used by a client to track mutations.
-  """
-  clientMutationId: String
-
-  """The \`StatusTemplate\` that was deleted by this mutation."""
-  statusTemplate: StatusTemplate
-
-  """
-  Our root query field type. Allows us to run any query from our mutation payload.
-  """
-  query: Query
-
-  """An edge for our \`StatusTemplate\`. May be used by Relay 1."""
-  statusTemplateEdge(
-    """The method to use when ordering \`StatusTemplate\`."""
-    orderBy: [StatusTemplateOrderBy!]! = [PRIMARY_KEY_ASC]
-  ): StatusTemplateEdge
-}
-
-"""All input for the \`deleteStatusTemplate\` mutation."""
-input DeleteStatusTemplateInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-  rowId: UUID!
-}
-
 """The output of our delete \`WardenSyncQueue\` mutation."""
 type DeleteWardenSyncQueuePayload {
   """
@@ -19321,6 +19315,39 @@ type DeleteSignalClusterPayload {
 
 """All input for the \`deleteSignalCluster\` mutation."""
 input DeleteSignalClusterInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  rowId: UUID!
+}
+
+"""The output of our delete \`StatusTemplate\` mutation."""
+type DeleteStatusTemplatePayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The \`StatusTemplate\` that was deleted by this mutation."""
+  statusTemplate: StatusTemplate
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our \`StatusTemplate\`. May be used by Relay 1."""
+  statusTemplateEdge(
+    """The method to use when ordering \`StatusTemplate\`."""
+    orderBy: [StatusTemplateOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): StatusTemplateEdge
+}
+
+"""All input for the \`deleteStatusTemplate\` mutation."""
+input DeleteStatusTemplateInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -19542,17 +19569,17 @@ type Query implements Node {
   """Get a single \`Attachment\`."""
   attachment(rowId: UUID!): Attachment
 
-  """Get a single \`StatusTemplate\`."""
-  statusTemplate(rowId: UUID!): StatusTemplate
-
-  """Get a single \`StatusTemplate\`."""
-  statusTemplateByOrganizationIdAndName(organizationId: UUID!, name: String!): StatusTemplate
-
   """Get a single \`WardenSyncQueue\`."""
   wardenSyncQueue(rowId: UUID!): WardenSyncQueue
 
   """Get a single \`SignalCluster\`."""
   signalCluster(rowId: UUID!): SignalCluster
+
+  """Get a single \`StatusTemplate\`."""
+  statusTemplate(rowId: UUID!): StatusTemplate
+
+  """Get a single \`StatusTemplate\`."""
+  statusTemplateByOrganizationIdAndName(organizationId: UUID!, name: String!): StatusTemplate
 
   """Get a single \`Signal\`."""
   signal(rowId: UUID!): Signal
@@ -19946,40 +19973,6 @@ type Query implements Node {
     orderBy: [AttachmentOrderBy!] = [PRIMARY_KEY_ASC]
   ): AttachmentConnection
 
-  """Reads and enables pagination through a set of \`StatusTemplate\`."""
-  statusTemplates(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: StatusTemplateCondition
-
-    """
-    A filter to be used in determining which values should be returned by the collection.
-    """
-    filter: StatusTemplateFilter
-
-    """The method to use when ordering \`StatusTemplate\`."""
-    orderBy: [StatusTemplateOrderBy!] = [PRIMARY_KEY_ASC]
-  ): StatusTemplateConnection
-
   """Reads and enables pagination through a set of \`WardenSyncQueue\`."""
   wardenSyncQueues(
     """Only read the first \`n\` values of the set."""
@@ -20047,6 +20040,40 @@ type Query implements Node {
     """The method to use when ordering \`SignalCluster\`."""
     orderBy: [SignalClusterOrderBy!] = [PRIMARY_KEY_ASC]
   ): SignalClusterConnection
+
+  """Reads and enables pagination through a set of \`StatusTemplate\`."""
+  statusTemplates(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: StatusTemplateCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: StatusTemplateFilter
+
+    """The method to use when ordering \`StatusTemplate\`."""
+    orderBy: [StatusTemplateOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StatusTemplateConnection
 
   """Reads and enables pagination through a set of \`Signal\`."""
   signals(
@@ -20249,14 +20276,6 @@ type Mutation {
     input: CreateAttachmentInput!
   ): CreateAttachmentPayload
 
-  """Creates a single \`StatusTemplate\`."""
-  createStatusTemplate(
-    """
-    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    """
-    input: CreateStatusTemplateInput!
-  ): CreateStatusTemplatePayload
-
   """Creates a single \`WardenSyncQueue\`."""
   createWardenSyncQueue(
     """
@@ -20272,6 +20291,14 @@ type Mutation {
     """
     input: CreateSignalClusterInput!
   ): CreateSignalClusterPayload
+
+  """Creates a single \`StatusTemplate\`."""
+  createStatusTemplate(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateStatusTemplateInput!
+  ): CreateStatusTemplatePayload
 
   """Creates a single \`Project\`."""
   createProject(
@@ -20369,14 +20396,6 @@ type Mutation {
     input: UpdateAttachmentInput!
   ): UpdateAttachmentPayload
 
-  """Updates a single \`StatusTemplate\` using a unique key and a patch."""
-  updateStatusTemplate(
-    """
-    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    """
-    input: UpdateStatusTemplateInput!
-  ): UpdateStatusTemplatePayload
-
   """Updates a single \`WardenSyncQueue\` using a unique key and a patch."""
   updateWardenSyncQueue(
     """
@@ -20392,6 +20411,14 @@ type Mutation {
     """
     input: UpdateSignalClusterInput!
   ): UpdateSignalClusterPayload
+
+  """Updates a single \`StatusTemplate\` using a unique key and a patch."""
+  updateStatusTemplate(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateStatusTemplateInput!
+  ): UpdateStatusTemplatePayload
 
   """Updates a single \`Project\` using a unique key and a patch."""
   updateProject(
@@ -20489,14 +20516,6 @@ type Mutation {
     input: DeleteAttachmentInput!
   ): DeleteAttachmentPayload
 
-  """Deletes a single \`StatusTemplate\` using a unique key."""
-  deleteStatusTemplate(
-    """
-    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    """
-    input: DeleteStatusTemplateInput!
-  ): DeleteStatusTemplatePayload
-
   """Deletes a single \`WardenSyncQueue\` using a unique key."""
   deleteWardenSyncQueue(
     """
@@ -20512,6 +20531,14 @@ type Mutation {
     """
     input: DeleteSignalClusterInput!
   ): DeleteSignalClusterPayload
+
+  """Deletes a single \`StatusTemplate\` using a unique key."""
+  deleteStatusTemplate(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteStatusTemplateInput!
+  ): DeleteStatusTemplatePayload
 
   """Deletes a single \`Project\` using a unique key."""
   deleteProject(
@@ -24106,6 +24133,9 @@ ${String(oldPlan36)}`);
         }
       },
       rowId: PostTag_rowIdPlan,
+      showOnBoard($record) {
+        return $record.get("show_on_board");
+      },
       showOnRoadmap($record) {
         return $record.get("show_on_roadmap");
       },
@@ -24166,6 +24196,9 @@ ${String(oldPlan36)}`);
       name: TagDistinctCountAggregates_namePlan,
       organizationId: StatusTemplateDistinctCountAggregates_organizationIdPlan,
       rowId: PostDistinctCountAggregates_rowIdPlan,
+      showOnBoard($pgSelectSingle) {
+        return pgAggregatesPlanAggregateAttribute(TYPES.boolean, "show_on_board", TYPES.bigint, pgAggregateSpec_distinctCount, $pgSelectSingle);
+      },
       showOnRoadmap($pgSelectSingle) {
         return pgAggregatesPlanAggregateAttribute(TYPES.boolean, "show_on_roadmap", TYPES.bigint, pgAggregateSpec_distinctCount, $pgSelectSingle);
       },
@@ -28912,6 +28945,9 @@ export const inputObjects = {
       name: TagCondition_nameApply,
       organizationId: StatusTemplateCondition_organizationIdApply,
       rowId: PostCondition_rowIdApply,
+      showOnBoard($condition, val) {
+        return applyAttributeCondition("show_on_board", TYPES.boolean, $condition, val);
+      },
       showOnRoadmap($condition, val) {
         return applyAttributeCondition("show_on_roadmap", TYPES.boolean, $condition, val);
       },
@@ -29019,6 +29055,9 @@ export const inputObjects = {
       },
       rowId(queryBuilder, value) {
         return pgConnectionFilterApplyAttribute("rowId", "id", spec_statusTemplate.attributes.id, queryBuilder, value);
+      },
+      showOnBoard(queryBuilder, value) {
+        return pgConnectionFilterApplyAttribute("showOnBoard", "show_on_board", spec_statusTemplate.attributes.show_on_board, queryBuilder, value);
       },
       showOnRoadmap(queryBuilder, value) {
         return pgConnectionFilterApplyAttribute("showOnRoadmap", "show_on_roadmap", spec_statusTemplate.attributes.show_on_roadmap, queryBuilder, value);
@@ -29174,6 +29213,7 @@ export const inputObjects = {
       name: TagInput_nameApply,
       organizationId: PostReferenceInput_organizationIdApply,
       rowId: PostTagInput_rowIdApply,
+      showOnBoard: StatusTemplateInput_showOnBoardApply,
       showOnRoadmap: StatusTemplateInput_showOnRoadmapApply,
       sortOrder: ProjectStatusConfigInput_sortOrderApply,
       updatedAt: TagInput_updatedAtApply
@@ -29190,6 +29230,7 @@ export const inputObjects = {
       name: TagInput_nameApply,
       organizationId: PostReferenceInput_organizationIdApply,
       rowId: PostTagInput_rowIdApply,
+      showOnBoard: StatusTemplateInput_showOnBoardApply,
       showOnRoadmap: StatusTemplateInput_showOnRoadmapApply,
       sortOrder: ProjectStatusConfigInput_sortOrderApply,
       updatedAt: TagInput_updatedAtApply
@@ -33595,6 +33636,9 @@ export const enums = {
       },
       NAME: TagGroupBy_NAMEApply,
       ORGANIZATION_ID: StatusTemplateGroupBy_ORGANIZATION_IDApply,
+      SHOW_ON_BOARD($pgSelect) {
+        applyGroupByAttribute("show_on_board", TYPES.boolean, $pgSelect);
+      },
       SHOW_ON_ROADMAP($pgSelect) {
         applyGroupByAttribute("show_on_roadmap", TYPES.boolean, $pgSelect);
       },
@@ -33972,6 +34016,18 @@ export const enums = {
       },
       ROW_ID_ASC: PostOrderBy_ROW_ID_ASCApply,
       ROW_ID_DESC: PostOrderBy_ROW_ID_DESCApply,
+      SHOW_ON_BOARD_ASC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "show_on_board",
+          direction: "ASC"
+        });
+      },
+      SHOW_ON_BOARD_DESC(queryBuilder) {
+        queryBuilder.orderBy({
+          attribute: "show_on_board",
+          direction: "DESC"
+        });
+      },
       SHOW_ON_ROADMAP_ASC(queryBuilder) {
         queryBuilder.orderBy({
           attribute: "show_on_roadmap",

--- a/src/generated/graphql/schema.graphql
+++ b/src/generated/graphql/schema.graphql
@@ -2639,6 +2639,9 @@ input StatusTemplateFilter {
   """Filter by the object’s `keywordRole` field."""
   keywordRole: StringFilter
 
+  """Filter by the object’s `showOnBoard` field."""
+  showOnBoard: BooleanFilter
+
   """Filter by the object’s `posts` relation."""
   posts: StatusTemplateToManyPostFilter
 
@@ -4200,6 +4203,7 @@ type StatusTemplate {
   updatedAt: Datetime!
   showOnRoadmap: Boolean
   keywordRole: String
+  showOnBoard: Boolean
 
   """Reads and enables pagination through a set of `Post`."""
   posts(
@@ -8265,429 +8269,6 @@ enum UserOrderBy {
   POST_STATUS_CHANGES_BY_CHANGED_BY_ID_DISTINCT_COUNT_NOTE_DESC
 }
 
-"""A connection to a list of `StatusTemplate` values."""
-type StatusTemplateConnection {
-  """A list of `StatusTemplate` objects."""
-  nodes: [StatusTemplate]!
-
-  """
-  A list of edges which contains the `StatusTemplate` and cursor to aid in pagination.
-  """
-  edges: [StatusTemplateEdge]!
-
-  """Information to aid in pagination."""
-  pageInfo: PageInfo!
-
-  """The count of *all* `StatusTemplate` you could get from the connection."""
-  totalCount: Int!
-
-  """
-  Aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  aggregates: StatusTemplateAggregates
-
-  """
-  Grouped aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  groupedAggregates(
-    """The method to use when grouping `StatusTemplate` for these aggregates."""
-    groupBy: [StatusTemplateGroupBy!]!
-
-    """Conditions on the grouped aggregates."""
-    having: StatusTemplateHavingInput
-  ): [StatusTemplateAggregates!]
-}
-
-"""A `StatusTemplate` edge in the connection."""
-type StatusTemplateEdge {
-  """A cursor for use in pagination."""
-  cursor: Cursor
-
-  """The `StatusTemplate` at the end of the edge."""
-  node: StatusTemplate
-}
-
-type StatusTemplateAggregates {
-  keys: [String]
-
-  """
-  Sum aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  sum: StatusTemplateSumAggregates
-
-  """
-  Distinct count aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  distinctCount: StatusTemplateDistinctCountAggregates
-
-  """
-  Minimum aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  min: StatusTemplateMinAggregates
-
-  """
-  Maximum aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  max: StatusTemplateMaxAggregates
-
-  """
-  Mean average aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  average: StatusTemplateAverageAggregates
-
-  """
-  Sample standard deviation aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  stddevSample: StatusTemplateStddevSampleAggregates
-
-  """
-  Population standard deviation aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  stddevPopulation: StatusTemplateStddevPopulationAggregates
-
-  """
-  Sample variance aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  varianceSample: StatusTemplateVarianceSampleAggregates
-
-  """
-  Population variance aggregates across the matching connection (ignoring before/after/first/last/offset)
-  """
-  variancePopulation: StatusTemplateVariancePopulationAggregates
-}
-
-type StatusTemplateSumAggregates {
-  """Sum of sortOrder across the matching connection"""
-  sortOrder: BigInt!
-}
-
-type StatusTemplateDistinctCountAggregates {
-  """Distinct count of rowId across the matching connection"""
-  rowId: BigInt
-
-  """Distinct count of organizationId across the matching connection"""
-  organizationId: BigInt
-
-  """Distinct count of name across the matching connection"""
-  name: BigInt
-
-  """Distinct count of displayName across the matching connection"""
-  displayName: BigInt
-
-  """Distinct count of color across the matching connection"""
-  color: BigInt
-
-  """Distinct count of description across the matching connection"""
-  description: BigInt
-
-  """Distinct count of sortOrder across the matching connection"""
-  sortOrder: BigInt
-
-  """Distinct count of createdAt across the matching connection"""
-  createdAt: BigInt
-
-  """Distinct count of updatedAt across the matching connection"""
-  updatedAt: BigInt
-
-  """Distinct count of showOnRoadmap across the matching connection"""
-  showOnRoadmap: BigInt
-
-  """Distinct count of keywordRole across the matching connection"""
-  keywordRole: BigInt
-}
-
-type StatusTemplateMinAggregates {
-  """Minimum of sortOrder across the matching connection"""
-  sortOrder: Int
-}
-
-type StatusTemplateMaxAggregates {
-  """Maximum of sortOrder across the matching connection"""
-  sortOrder: Int
-}
-
-type StatusTemplateAverageAggregates {
-  """Mean average of sortOrder across the matching connection"""
-  sortOrder: BigFloat
-}
-
-type StatusTemplateStddevSampleAggregates {
-  """Sample standard deviation of sortOrder across the matching connection"""
-  sortOrder: BigFloat
-}
-
-type StatusTemplateStddevPopulationAggregates {
-  """
-  Population standard deviation of sortOrder across the matching connection
-  """
-  sortOrder: BigFloat
-}
-
-type StatusTemplateVarianceSampleAggregates {
-  """Sample variance of sortOrder across the matching connection"""
-  sortOrder: BigFloat
-}
-
-type StatusTemplateVariancePopulationAggregates {
-  """Population variance of sortOrder across the matching connection"""
-  sortOrder: BigFloat
-}
-
-"""Grouping methods for `StatusTemplate` for usage during aggregation."""
-enum StatusTemplateGroupBy {
-  ORGANIZATION_ID
-  NAME
-  DISPLAY_NAME
-  COLOR
-  DESCRIPTION
-  SORT_ORDER
-  CREATED_AT
-  CREATED_AT_TRUNCATED_TO_HOUR
-  CREATED_AT_TRUNCATED_TO_DAY
-  UPDATED_AT
-  UPDATED_AT_TRUNCATED_TO_HOUR
-  UPDATED_AT_TRUNCATED_TO_DAY
-  SHOW_ON_ROADMAP
-  KEYWORD_ROLE
-}
-
-"""Conditions for `StatusTemplate` aggregates."""
-input StatusTemplateHavingInput {
-  AND: [StatusTemplateHavingInput!]
-  OR: [StatusTemplateHavingInput!]
-  sum: StatusTemplateHavingSumInput
-  distinctCount: StatusTemplateHavingDistinctCountInput
-  min: StatusTemplateHavingMinInput
-  max: StatusTemplateHavingMaxInput
-  average: StatusTemplateHavingAverageInput
-  stddevSample: StatusTemplateHavingStddevSampleInput
-  stddevPopulation: StatusTemplateHavingStddevPopulationInput
-  varianceSample: StatusTemplateHavingVarianceSampleInput
-  variancePopulation: StatusTemplateHavingVariancePopulationInput
-}
-
-input StatusTemplateHavingSumInput {
-  sortOrder: HavingIntFilter
-  createdAt: HavingDatetimeFilter
-  updatedAt: HavingDatetimeFilter
-}
-
-input StatusTemplateHavingDistinctCountInput {
-  sortOrder: HavingIntFilter
-  createdAt: HavingDatetimeFilter
-  updatedAt: HavingDatetimeFilter
-}
-
-input StatusTemplateHavingMinInput {
-  sortOrder: HavingIntFilter
-  createdAt: HavingDatetimeFilter
-  updatedAt: HavingDatetimeFilter
-}
-
-input StatusTemplateHavingMaxInput {
-  sortOrder: HavingIntFilter
-  createdAt: HavingDatetimeFilter
-  updatedAt: HavingDatetimeFilter
-}
-
-input StatusTemplateHavingAverageInput {
-  sortOrder: HavingIntFilter
-  createdAt: HavingDatetimeFilter
-  updatedAt: HavingDatetimeFilter
-}
-
-input StatusTemplateHavingStddevSampleInput {
-  sortOrder: HavingIntFilter
-  createdAt: HavingDatetimeFilter
-  updatedAt: HavingDatetimeFilter
-}
-
-input StatusTemplateHavingStddevPopulationInput {
-  sortOrder: HavingIntFilter
-  createdAt: HavingDatetimeFilter
-  updatedAt: HavingDatetimeFilter
-}
-
-input StatusTemplateHavingVarianceSampleInput {
-  sortOrder: HavingIntFilter
-  createdAt: HavingDatetimeFilter
-  updatedAt: HavingDatetimeFilter
-}
-
-input StatusTemplateHavingVariancePopulationInput {
-  sortOrder: HavingIntFilter
-  createdAt: HavingDatetimeFilter
-  updatedAt: HavingDatetimeFilter
-}
-
-"""
-A condition to be used against `StatusTemplate` object types. All fields are
-tested for equality and combined with a logical ‘and.’
-"""
-input StatusTemplateCondition {
-  """Checks for equality with the object’s `rowId` field."""
-  rowId: UUID
-
-  """Checks for equality with the object’s `organizationId` field."""
-  organizationId: UUID
-
-  """Checks for equality with the object’s `name` field."""
-  name: String
-
-  """Checks for equality with the object’s `displayName` field."""
-  displayName: String
-
-  """Checks for equality with the object’s `color` field."""
-  color: String
-
-  """Checks for equality with the object’s `description` field."""
-  description: String
-
-  """Checks for equality with the object’s `sortOrder` field."""
-  sortOrder: Int
-
-  """Checks for equality with the object’s `createdAt` field."""
-  createdAt: Datetime
-
-  """Checks for equality with the object’s `updatedAt` field."""
-  updatedAt: Datetime
-
-  """Checks for equality with the object’s `showOnRoadmap` field."""
-  showOnRoadmap: Boolean
-
-  """Checks for equality with the object’s `keywordRole` field."""
-  keywordRole: String
-}
-
-"""Methods to use when ordering `StatusTemplate`."""
-enum StatusTemplateOrderBy {
-  NATURAL
-  PRIMARY_KEY_ASC
-  PRIMARY_KEY_DESC
-  ROW_ID_ASC
-  ROW_ID_DESC
-  ORGANIZATION_ID_ASC
-  ORGANIZATION_ID_DESC
-  NAME_ASC
-  NAME_DESC
-  DISPLAY_NAME_ASC
-  DISPLAY_NAME_DESC
-  COLOR_ASC
-  COLOR_DESC
-  DESCRIPTION_ASC
-  DESCRIPTION_DESC
-  SORT_ORDER_ASC
-  SORT_ORDER_DESC
-  CREATED_AT_ASC
-  CREATED_AT_DESC
-  UPDATED_AT_ASC
-  UPDATED_AT_DESC
-  SHOW_ON_ROADMAP_ASC
-  SHOW_ON_ROADMAP_DESC
-  KEYWORD_ROLE_ASC
-  KEYWORD_ROLE_DESC
-  POSTS_COUNT_ASC
-  POSTS_COUNT_DESC
-  POSTS_SUM_NUMBER_ASC
-  POSTS_SUM_NUMBER_DESC
-  POSTS_DISTINCT_COUNT_ROW_ID_ASC
-  POSTS_DISTINCT_COUNT_ROW_ID_DESC
-  POSTS_DISTINCT_COUNT_TITLE_ASC
-  POSTS_DISTINCT_COUNT_TITLE_DESC
-  POSTS_DISTINCT_COUNT_DESCRIPTION_ASC
-  POSTS_DISTINCT_COUNT_DESCRIPTION_DESC
-  POSTS_DISTINCT_COUNT_PROJECT_ID_ASC
-  POSTS_DISTINCT_COUNT_PROJECT_ID_DESC
-  POSTS_DISTINCT_COUNT_USER_ID_ASC
-  POSTS_DISTINCT_COUNT_USER_ID_DESC
-  POSTS_DISTINCT_COUNT_STATUS_TEMPLATE_ID_ASC
-  POSTS_DISTINCT_COUNT_STATUS_TEMPLATE_ID_DESC
-  POSTS_DISTINCT_COUNT_STATUS_UPDATED_AT_ASC
-  POSTS_DISTINCT_COUNT_STATUS_UPDATED_AT_DESC
-  POSTS_DISTINCT_COUNT_CREATED_AT_ASC
-  POSTS_DISTINCT_COUNT_CREATED_AT_DESC
-  POSTS_DISTINCT_COUNT_UPDATED_AT_ASC
-  POSTS_DISTINCT_COUNT_UPDATED_AT_DESC
-  POSTS_DISTINCT_COUNT_NUMBER_ASC
-  POSTS_DISTINCT_COUNT_NUMBER_DESC
-  POSTS_DISTINCT_COUNT_SOURCE_ASC
-  POSTS_DISTINCT_COUNT_SOURCE_DESC
-  POSTS_DISTINCT_COUNT_SENTIMENT_ASC
-  POSTS_DISTINCT_COUNT_SENTIMENT_DESC
-  POSTS_DISTINCT_COUNT_AI_TAGS_ASC
-  POSTS_DISTINCT_COUNT_AI_TAGS_DESC
-  POSTS_DISTINCT_COUNT_DUPLICATE_OF_ID_ASC
-  POSTS_DISTINCT_COUNT_DUPLICATE_OF_ID_DESC
-  POSTS_DISTINCT_COUNT_CLUSTER_ID_ASC
-  POSTS_DISTINCT_COUNT_CLUSTER_ID_DESC
-  POSTS_DISTINCT_COUNT_SHIPPED_AT_ASC
-  POSTS_DISTINCT_COUNT_SHIPPED_AT_DESC
-  POSTS_MIN_NUMBER_ASC
-  POSTS_MIN_NUMBER_DESC
-  POSTS_MAX_NUMBER_ASC
-  POSTS_MAX_NUMBER_DESC
-  POSTS_AVERAGE_NUMBER_ASC
-  POSTS_AVERAGE_NUMBER_DESC
-  POSTS_STDDEV_SAMPLE_NUMBER_ASC
-  POSTS_STDDEV_SAMPLE_NUMBER_DESC
-  POSTS_STDDEV_POPULATION_NUMBER_ASC
-  POSTS_STDDEV_POPULATION_NUMBER_DESC
-  POSTS_VARIANCE_SAMPLE_NUMBER_ASC
-  POSTS_VARIANCE_SAMPLE_NUMBER_DESC
-  POSTS_VARIANCE_POPULATION_NUMBER_ASC
-  POSTS_VARIANCE_POPULATION_NUMBER_DESC
-  PROJECT_STATUS_CONFIGS_COUNT_ASC
-  PROJECT_STATUS_CONFIGS_COUNT_DESC
-  PROJECT_STATUS_CONFIGS_SUM_SORT_ORDER_ASC
-  PROJECT_STATUS_CONFIGS_SUM_SORT_ORDER_DESC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_ROW_ID_ASC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_ROW_ID_DESC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_PROJECT_ID_ASC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_PROJECT_ID_DESC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_STATUS_TEMPLATE_ID_ASC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_STATUS_TEMPLATE_ID_DESC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CUSTOM_COLOR_ASC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CUSTOM_COLOR_DESC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CUSTOM_DESCRIPTION_ASC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CUSTOM_DESCRIPTION_DESC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_IS_ENABLED_ASC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_IS_ENABLED_DESC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_IS_DEFAULT_ASC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_IS_DEFAULT_DESC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_SORT_ORDER_ASC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_SORT_ORDER_DESC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CREATED_AT_ASC
-  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CREATED_AT_DESC
-  PROJECT_STATUS_CONFIGS_MIN_SORT_ORDER_ASC
-  PROJECT_STATUS_CONFIGS_MIN_SORT_ORDER_DESC
-  PROJECT_STATUS_CONFIGS_MAX_SORT_ORDER_ASC
-  PROJECT_STATUS_CONFIGS_MAX_SORT_ORDER_DESC
-  PROJECT_STATUS_CONFIGS_AVERAGE_SORT_ORDER_ASC
-  PROJECT_STATUS_CONFIGS_AVERAGE_SORT_ORDER_DESC
-  PROJECT_STATUS_CONFIGS_STDDEV_SAMPLE_SORT_ORDER_ASC
-  PROJECT_STATUS_CONFIGS_STDDEV_SAMPLE_SORT_ORDER_DESC
-  PROJECT_STATUS_CONFIGS_STDDEV_POPULATION_SORT_ORDER_ASC
-  PROJECT_STATUS_CONFIGS_STDDEV_POPULATION_SORT_ORDER_DESC
-  PROJECT_STATUS_CONFIGS_VARIANCE_SAMPLE_SORT_ORDER_ASC
-  PROJECT_STATUS_CONFIGS_VARIANCE_SAMPLE_SORT_ORDER_DESC
-  PROJECT_STATUS_CONFIGS_VARIANCE_POPULATION_SORT_ORDER_ASC
-  PROJECT_STATUS_CONFIGS_VARIANCE_POPULATION_SORT_ORDER_DESC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_COUNT_ASC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_COUNT_DESC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_ROW_ID_ASC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_ROW_ID_DESC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_POST_ID_ASC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_POST_ID_DESC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_TO_STATUS_TEMPLATE_ID_ASC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_TO_STATUS_TEMPLATE_ID_DESC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_CHANGED_BY_ID_ASC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_CHANGED_BY_ID_DESC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_CREATED_AT_ASC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_CREATED_AT_DESC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_NOTE_ASC
-  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_NOTE_DESC
-}
-
 """A connection to a list of `WardenSyncQueue` values."""
 type WardenSyncQueueConnection {
   """A list of `WardenSyncQueue` objects."""
@@ -9053,6 +8634,438 @@ enum WardenSyncQueueOrderBy {
   NEXT_RETRY_AT_DESC
   CREATED_AT_ASC
   CREATED_AT_DESC
+}
+
+"""A connection to a list of `StatusTemplate` values."""
+type StatusTemplateConnection {
+  """A list of `StatusTemplate` objects."""
+  nodes: [StatusTemplate]!
+
+  """
+  A list of edges which contains the `StatusTemplate` and cursor to aid in pagination.
+  """
+  edges: [StatusTemplateEdge]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `StatusTemplate` you could get from the connection."""
+  totalCount: Int!
+
+  """
+  Aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  aggregates: StatusTemplateAggregates
+
+  """
+  Grouped aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  groupedAggregates(
+    """The method to use when grouping `StatusTemplate` for these aggregates."""
+    groupBy: [StatusTemplateGroupBy!]!
+
+    """Conditions on the grouped aggregates."""
+    having: StatusTemplateHavingInput
+  ): [StatusTemplateAggregates!]
+}
+
+"""A `StatusTemplate` edge in the connection."""
+type StatusTemplateEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `StatusTemplate` at the end of the edge."""
+  node: StatusTemplate
+}
+
+type StatusTemplateAggregates {
+  keys: [String]
+
+  """
+  Sum aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  sum: StatusTemplateSumAggregates
+
+  """
+  Distinct count aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  distinctCount: StatusTemplateDistinctCountAggregates
+
+  """
+  Minimum aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  min: StatusTemplateMinAggregates
+
+  """
+  Maximum aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  max: StatusTemplateMaxAggregates
+
+  """
+  Mean average aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  average: StatusTemplateAverageAggregates
+
+  """
+  Sample standard deviation aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  stddevSample: StatusTemplateStddevSampleAggregates
+
+  """
+  Population standard deviation aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  stddevPopulation: StatusTemplateStddevPopulationAggregates
+
+  """
+  Sample variance aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  varianceSample: StatusTemplateVarianceSampleAggregates
+
+  """
+  Population variance aggregates across the matching connection (ignoring before/after/first/last/offset)
+  """
+  variancePopulation: StatusTemplateVariancePopulationAggregates
+}
+
+type StatusTemplateSumAggregates {
+  """Sum of sortOrder across the matching connection"""
+  sortOrder: BigInt!
+}
+
+type StatusTemplateDistinctCountAggregates {
+  """Distinct count of rowId across the matching connection"""
+  rowId: BigInt
+
+  """Distinct count of organizationId across the matching connection"""
+  organizationId: BigInt
+
+  """Distinct count of name across the matching connection"""
+  name: BigInt
+
+  """Distinct count of displayName across the matching connection"""
+  displayName: BigInt
+
+  """Distinct count of color across the matching connection"""
+  color: BigInt
+
+  """Distinct count of description across the matching connection"""
+  description: BigInt
+
+  """Distinct count of sortOrder across the matching connection"""
+  sortOrder: BigInt
+
+  """Distinct count of createdAt across the matching connection"""
+  createdAt: BigInt
+
+  """Distinct count of updatedAt across the matching connection"""
+  updatedAt: BigInt
+
+  """Distinct count of showOnRoadmap across the matching connection"""
+  showOnRoadmap: BigInt
+
+  """Distinct count of keywordRole across the matching connection"""
+  keywordRole: BigInt
+
+  """Distinct count of showOnBoard across the matching connection"""
+  showOnBoard: BigInt
+}
+
+type StatusTemplateMinAggregates {
+  """Minimum of sortOrder across the matching connection"""
+  sortOrder: Int
+}
+
+type StatusTemplateMaxAggregates {
+  """Maximum of sortOrder across the matching connection"""
+  sortOrder: Int
+}
+
+type StatusTemplateAverageAggregates {
+  """Mean average of sortOrder across the matching connection"""
+  sortOrder: BigFloat
+}
+
+type StatusTemplateStddevSampleAggregates {
+  """Sample standard deviation of sortOrder across the matching connection"""
+  sortOrder: BigFloat
+}
+
+type StatusTemplateStddevPopulationAggregates {
+  """
+  Population standard deviation of sortOrder across the matching connection
+  """
+  sortOrder: BigFloat
+}
+
+type StatusTemplateVarianceSampleAggregates {
+  """Sample variance of sortOrder across the matching connection"""
+  sortOrder: BigFloat
+}
+
+type StatusTemplateVariancePopulationAggregates {
+  """Population variance of sortOrder across the matching connection"""
+  sortOrder: BigFloat
+}
+
+"""Grouping methods for `StatusTemplate` for usage during aggregation."""
+enum StatusTemplateGroupBy {
+  ORGANIZATION_ID
+  NAME
+  DISPLAY_NAME
+  COLOR
+  DESCRIPTION
+  SORT_ORDER
+  CREATED_AT
+  CREATED_AT_TRUNCATED_TO_HOUR
+  CREATED_AT_TRUNCATED_TO_DAY
+  UPDATED_AT
+  UPDATED_AT_TRUNCATED_TO_HOUR
+  UPDATED_AT_TRUNCATED_TO_DAY
+  SHOW_ON_ROADMAP
+  KEYWORD_ROLE
+  SHOW_ON_BOARD
+}
+
+"""Conditions for `StatusTemplate` aggregates."""
+input StatusTemplateHavingInput {
+  AND: [StatusTemplateHavingInput!]
+  OR: [StatusTemplateHavingInput!]
+  sum: StatusTemplateHavingSumInput
+  distinctCount: StatusTemplateHavingDistinctCountInput
+  min: StatusTemplateHavingMinInput
+  max: StatusTemplateHavingMaxInput
+  average: StatusTemplateHavingAverageInput
+  stddevSample: StatusTemplateHavingStddevSampleInput
+  stddevPopulation: StatusTemplateHavingStddevPopulationInput
+  varianceSample: StatusTemplateHavingVarianceSampleInput
+  variancePopulation: StatusTemplateHavingVariancePopulationInput
+}
+
+input StatusTemplateHavingSumInput {
+  sortOrder: HavingIntFilter
+  createdAt: HavingDatetimeFilter
+  updatedAt: HavingDatetimeFilter
+}
+
+input StatusTemplateHavingDistinctCountInput {
+  sortOrder: HavingIntFilter
+  createdAt: HavingDatetimeFilter
+  updatedAt: HavingDatetimeFilter
+}
+
+input StatusTemplateHavingMinInput {
+  sortOrder: HavingIntFilter
+  createdAt: HavingDatetimeFilter
+  updatedAt: HavingDatetimeFilter
+}
+
+input StatusTemplateHavingMaxInput {
+  sortOrder: HavingIntFilter
+  createdAt: HavingDatetimeFilter
+  updatedAt: HavingDatetimeFilter
+}
+
+input StatusTemplateHavingAverageInput {
+  sortOrder: HavingIntFilter
+  createdAt: HavingDatetimeFilter
+  updatedAt: HavingDatetimeFilter
+}
+
+input StatusTemplateHavingStddevSampleInput {
+  sortOrder: HavingIntFilter
+  createdAt: HavingDatetimeFilter
+  updatedAt: HavingDatetimeFilter
+}
+
+input StatusTemplateHavingStddevPopulationInput {
+  sortOrder: HavingIntFilter
+  createdAt: HavingDatetimeFilter
+  updatedAt: HavingDatetimeFilter
+}
+
+input StatusTemplateHavingVarianceSampleInput {
+  sortOrder: HavingIntFilter
+  createdAt: HavingDatetimeFilter
+  updatedAt: HavingDatetimeFilter
+}
+
+input StatusTemplateHavingVariancePopulationInput {
+  sortOrder: HavingIntFilter
+  createdAt: HavingDatetimeFilter
+  updatedAt: HavingDatetimeFilter
+}
+
+"""
+A condition to be used against `StatusTemplate` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input StatusTemplateCondition {
+  """Checks for equality with the object’s `rowId` field."""
+  rowId: UUID
+
+  """Checks for equality with the object’s `organizationId` field."""
+  organizationId: UUID
+
+  """Checks for equality with the object’s `name` field."""
+  name: String
+
+  """Checks for equality with the object’s `displayName` field."""
+  displayName: String
+
+  """Checks for equality with the object’s `color` field."""
+  color: String
+
+  """Checks for equality with the object’s `description` field."""
+  description: String
+
+  """Checks for equality with the object’s `sortOrder` field."""
+  sortOrder: Int
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+
+  """Checks for equality with the object’s `showOnRoadmap` field."""
+  showOnRoadmap: Boolean
+
+  """Checks for equality with the object’s `keywordRole` field."""
+  keywordRole: String
+
+  """Checks for equality with the object’s `showOnBoard` field."""
+  showOnBoard: Boolean
+}
+
+"""Methods to use when ordering `StatusTemplate`."""
+enum StatusTemplateOrderBy {
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  ROW_ID_ASC
+  ROW_ID_DESC
+  ORGANIZATION_ID_ASC
+  ORGANIZATION_ID_DESC
+  NAME_ASC
+  NAME_DESC
+  DISPLAY_NAME_ASC
+  DISPLAY_NAME_DESC
+  COLOR_ASC
+  COLOR_DESC
+  DESCRIPTION_ASC
+  DESCRIPTION_DESC
+  SORT_ORDER_ASC
+  SORT_ORDER_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  SHOW_ON_ROADMAP_ASC
+  SHOW_ON_ROADMAP_DESC
+  KEYWORD_ROLE_ASC
+  KEYWORD_ROLE_DESC
+  SHOW_ON_BOARD_ASC
+  SHOW_ON_BOARD_DESC
+  POSTS_COUNT_ASC
+  POSTS_COUNT_DESC
+  POSTS_SUM_NUMBER_ASC
+  POSTS_SUM_NUMBER_DESC
+  POSTS_DISTINCT_COUNT_ROW_ID_ASC
+  POSTS_DISTINCT_COUNT_ROW_ID_DESC
+  POSTS_DISTINCT_COUNT_TITLE_ASC
+  POSTS_DISTINCT_COUNT_TITLE_DESC
+  POSTS_DISTINCT_COUNT_DESCRIPTION_ASC
+  POSTS_DISTINCT_COUNT_DESCRIPTION_DESC
+  POSTS_DISTINCT_COUNT_PROJECT_ID_ASC
+  POSTS_DISTINCT_COUNT_PROJECT_ID_DESC
+  POSTS_DISTINCT_COUNT_USER_ID_ASC
+  POSTS_DISTINCT_COUNT_USER_ID_DESC
+  POSTS_DISTINCT_COUNT_STATUS_TEMPLATE_ID_ASC
+  POSTS_DISTINCT_COUNT_STATUS_TEMPLATE_ID_DESC
+  POSTS_DISTINCT_COUNT_STATUS_UPDATED_AT_ASC
+  POSTS_DISTINCT_COUNT_STATUS_UPDATED_AT_DESC
+  POSTS_DISTINCT_COUNT_CREATED_AT_ASC
+  POSTS_DISTINCT_COUNT_CREATED_AT_DESC
+  POSTS_DISTINCT_COUNT_UPDATED_AT_ASC
+  POSTS_DISTINCT_COUNT_UPDATED_AT_DESC
+  POSTS_DISTINCT_COUNT_NUMBER_ASC
+  POSTS_DISTINCT_COUNT_NUMBER_DESC
+  POSTS_DISTINCT_COUNT_SOURCE_ASC
+  POSTS_DISTINCT_COUNT_SOURCE_DESC
+  POSTS_DISTINCT_COUNT_SENTIMENT_ASC
+  POSTS_DISTINCT_COUNT_SENTIMENT_DESC
+  POSTS_DISTINCT_COUNT_AI_TAGS_ASC
+  POSTS_DISTINCT_COUNT_AI_TAGS_DESC
+  POSTS_DISTINCT_COUNT_DUPLICATE_OF_ID_ASC
+  POSTS_DISTINCT_COUNT_DUPLICATE_OF_ID_DESC
+  POSTS_DISTINCT_COUNT_CLUSTER_ID_ASC
+  POSTS_DISTINCT_COUNT_CLUSTER_ID_DESC
+  POSTS_DISTINCT_COUNT_SHIPPED_AT_ASC
+  POSTS_DISTINCT_COUNT_SHIPPED_AT_DESC
+  POSTS_MIN_NUMBER_ASC
+  POSTS_MIN_NUMBER_DESC
+  POSTS_MAX_NUMBER_ASC
+  POSTS_MAX_NUMBER_DESC
+  POSTS_AVERAGE_NUMBER_ASC
+  POSTS_AVERAGE_NUMBER_DESC
+  POSTS_STDDEV_SAMPLE_NUMBER_ASC
+  POSTS_STDDEV_SAMPLE_NUMBER_DESC
+  POSTS_STDDEV_POPULATION_NUMBER_ASC
+  POSTS_STDDEV_POPULATION_NUMBER_DESC
+  POSTS_VARIANCE_SAMPLE_NUMBER_ASC
+  POSTS_VARIANCE_SAMPLE_NUMBER_DESC
+  POSTS_VARIANCE_POPULATION_NUMBER_ASC
+  POSTS_VARIANCE_POPULATION_NUMBER_DESC
+  PROJECT_STATUS_CONFIGS_COUNT_ASC
+  PROJECT_STATUS_CONFIGS_COUNT_DESC
+  PROJECT_STATUS_CONFIGS_SUM_SORT_ORDER_ASC
+  PROJECT_STATUS_CONFIGS_SUM_SORT_ORDER_DESC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_ROW_ID_ASC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_ROW_ID_DESC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_PROJECT_ID_ASC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_PROJECT_ID_DESC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_STATUS_TEMPLATE_ID_ASC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_STATUS_TEMPLATE_ID_DESC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CUSTOM_COLOR_ASC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CUSTOM_COLOR_DESC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CUSTOM_DESCRIPTION_ASC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CUSTOM_DESCRIPTION_DESC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_IS_ENABLED_ASC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_IS_ENABLED_DESC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_IS_DEFAULT_ASC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_IS_DEFAULT_DESC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_SORT_ORDER_ASC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_SORT_ORDER_DESC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CREATED_AT_ASC
+  PROJECT_STATUS_CONFIGS_DISTINCT_COUNT_CREATED_AT_DESC
+  PROJECT_STATUS_CONFIGS_MIN_SORT_ORDER_ASC
+  PROJECT_STATUS_CONFIGS_MIN_SORT_ORDER_DESC
+  PROJECT_STATUS_CONFIGS_MAX_SORT_ORDER_ASC
+  PROJECT_STATUS_CONFIGS_MAX_SORT_ORDER_DESC
+  PROJECT_STATUS_CONFIGS_AVERAGE_SORT_ORDER_ASC
+  PROJECT_STATUS_CONFIGS_AVERAGE_SORT_ORDER_DESC
+  PROJECT_STATUS_CONFIGS_STDDEV_SAMPLE_SORT_ORDER_ASC
+  PROJECT_STATUS_CONFIGS_STDDEV_SAMPLE_SORT_ORDER_DESC
+  PROJECT_STATUS_CONFIGS_STDDEV_POPULATION_SORT_ORDER_ASC
+  PROJECT_STATUS_CONFIGS_STDDEV_POPULATION_SORT_ORDER_DESC
+  PROJECT_STATUS_CONFIGS_VARIANCE_SAMPLE_SORT_ORDER_ASC
+  PROJECT_STATUS_CONFIGS_VARIANCE_SAMPLE_SORT_ORDER_DESC
+  PROJECT_STATUS_CONFIGS_VARIANCE_POPULATION_SORT_ORDER_ASC
+  PROJECT_STATUS_CONFIGS_VARIANCE_POPULATION_SORT_ORDER_DESC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_COUNT_ASC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_COUNT_DESC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_ROW_ID_ASC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_ROW_ID_DESC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_POST_ID_ASC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_POST_ID_DESC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_TO_STATUS_TEMPLATE_ID_ASC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_TO_STATUS_TEMPLATE_ID_DESC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_CHANGED_BY_ID_ASC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_CHANGED_BY_ID_DESC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_CREATED_AT_ASC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_CREATED_AT_DESC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_NOTE_ASC
+  POST_STATUS_CHANGES_BY_TO_STATUS_TEMPLATE_ID_DISTINCT_COUNT_NOTE_DESC
 }
 
 """A connection to a list of `Project` values."""
@@ -10066,56 +10079,6 @@ input AttachmentInput {
   createdAt: Datetime
 }
 
-"""The output of our create `StatusTemplate` mutation."""
-type CreateStatusTemplatePayload {
-  """
-  The exact same `clientMutationId` that was provided in the mutation input,
-  unchanged and unused. May be used by a client to track mutations.
-  """
-  clientMutationId: String
-
-  """The `StatusTemplate` that was created by this mutation."""
-  statusTemplate: StatusTemplate
-
-  """
-  Our root query field type. Allows us to run any query from our mutation payload.
-  """
-  query: Query
-
-  """An edge for our `StatusTemplate`. May be used by Relay 1."""
-  statusTemplateEdge(
-    """The method to use when ordering `StatusTemplate`."""
-    orderBy: [StatusTemplateOrderBy!]! = [PRIMARY_KEY_ASC]
-  ): StatusTemplateEdge
-}
-
-"""All input for the create `StatusTemplate` mutation."""
-input CreateStatusTemplateInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-
-  """The `StatusTemplate` to be created by this mutation."""
-  statusTemplate: StatusTemplateInput!
-}
-
-"""An input for mutations affecting `StatusTemplate`"""
-input StatusTemplateInput {
-  rowId: UUID
-  organizationId: UUID!
-  name: String!
-  displayName: String!
-  color: String
-  description: String
-  sortOrder: Int
-  createdAt: Datetime
-  updatedAt: Datetime
-  showOnRoadmap: Boolean
-  keywordRole: String
-}
-
 """The output of our create `WardenSyncQueue` mutation."""
 type CreateWardenSyncQueuePayload {
   """
@@ -10207,6 +10170,57 @@ input SignalClusterInput {
   memberCount: Int
   createdAt: Datetime
   updatedAt: Datetime
+}
+
+"""The output of our create `StatusTemplate` mutation."""
+type CreateStatusTemplatePayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `StatusTemplate` that was created by this mutation."""
+  statusTemplate: StatusTemplate
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `StatusTemplate`. May be used by Relay 1."""
+  statusTemplateEdge(
+    """The method to use when ordering `StatusTemplate`."""
+    orderBy: [StatusTemplateOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): StatusTemplateEdge
+}
+
+"""All input for the create `StatusTemplate` mutation."""
+input CreateStatusTemplateInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `StatusTemplate` to be created by this mutation."""
+  statusTemplate: StatusTemplateInput!
+}
+
+"""An input for mutations affecting `StatusTemplate`"""
+input StatusTemplateInput {
+  rowId: UUID
+  organizationId: UUID!
+  name: String!
+  displayName: String!
+  color: String
+  description: String
+  sortOrder: Int
+  createdAt: Datetime
+  updatedAt: Datetime
+  showOnRoadmap: Boolean
+  keywordRole: String
+  showOnBoard: Boolean
 }
 
 """The output of our create `Project` mutation."""
@@ -10824,61 +10838,6 @@ input AttachmentPatch {
   createdAt: Datetime
 }
 
-"""The output of our update `StatusTemplate` mutation."""
-type UpdateStatusTemplatePayload {
-  """
-  The exact same `clientMutationId` that was provided in the mutation input,
-  unchanged and unused. May be used by a client to track mutations.
-  """
-  clientMutationId: String
-
-  """The `StatusTemplate` that was updated by this mutation."""
-  statusTemplate: StatusTemplate
-
-  """
-  Our root query field type. Allows us to run any query from our mutation payload.
-  """
-  query: Query
-
-  """An edge for our `StatusTemplate`. May be used by Relay 1."""
-  statusTemplateEdge(
-    """The method to use when ordering `StatusTemplate`."""
-    orderBy: [StatusTemplateOrderBy!]! = [PRIMARY_KEY_ASC]
-  ): StatusTemplateEdge
-}
-
-"""All input for the `updateStatusTemplate` mutation."""
-input UpdateStatusTemplateInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-  rowId: UUID!
-
-  """
-  An object where the defined keys will be set on the `StatusTemplate` being updated.
-  """
-  patch: StatusTemplatePatch!
-}
-
-"""
-Represents an update to a `StatusTemplate`. Fields that are set will be updated.
-"""
-input StatusTemplatePatch {
-  rowId: UUID
-  organizationId: UUID
-  name: String
-  displayName: String
-  color: String
-  description: String
-  sortOrder: Int
-  createdAt: Datetime
-  updatedAt: Datetime
-  showOnRoadmap: Boolean
-  keywordRole: String
-}
-
 """The output of our update `WardenSyncQueue` mutation."""
 type UpdateWardenSyncQueuePayload {
   """
@@ -10980,6 +10939,62 @@ input SignalClusterPatch {
   memberCount: Int
   createdAt: Datetime
   updatedAt: Datetime
+}
+
+"""The output of our update `StatusTemplate` mutation."""
+type UpdateStatusTemplatePayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `StatusTemplate` that was updated by this mutation."""
+  statusTemplate: StatusTemplate
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `StatusTemplate`. May be used by Relay 1."""
+  statusTemplateEdge(
+    """The method to use when ordering `StatusTemplate`."""
+    orderBy: [StatusTemplateOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): StatusTemplateEdge
+}
+
+"""All input for the `updateStatusTemplate` mutation."""
+input UpdateStatusTemplateInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  rowId: UUID!
+
+  """
+  An object where the defined keys will be set on the `StatusTemplate` being updated.
+  """
+  patch: StatusTemplatePatch!
+}
+
+"""
+Represents an update to a `StatusTemplate`. Fields that are set will be updated.
+"""
+input StatusTemplatePatch {
+  rowId: UUID
+  organizationId: UUID
+  name: String
+  displayName: String
+  color: String
+  description: String
+  sortOrder: Int
+  createdAt: Datetime
+  updatedAt: Datetime
+  showOnRoadmap: Boolean
+  keywordRole: String
+  showOnBoard: Boolean
 }
 
 """The output of our update `Project` mutation."""
@@ -11426,39 +11441,6 @@ input DeleteAttachmentInput {
   rowId: UUID!
 }
 
-"""The output of our delete `StatusTemplate` mutation."""
-type DeleteStatusTemplatePayload {
-  """
-  The exact same `clientMutationId` that was provided in the mutation input,
-  unchanged and unused. May be used by a client to track mutations.
-  """
-  clientMutationId: String
-
-  """The `StatusTemplate` that was deleted by this mutation."""
-  statusTemplate: StatusTemplate
-
-  """
-  Our root query field type. Allows us to run any query from our mutation payload.
-  """
-  query: Query
-
-  """An edge for our `StatusTemplate`. May be used by Relay 1."""
-  statusTemplateEdge(
-    """The method to use when ordering `StatusTemplate`."""
-    orderBy: [StatusTemplateOrderBy!]! = [PRIMARY_KEY_ASC]
-  ): StatusTemplateEdge
-}
-
-"""All input for the `deleteStatusTemplate` mutation."""
-input DeleteStatusTemplateInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-  rowId: UUID!
-}
-
 """The output of our delete `WardenSyncQueue` mutation."""
 type DeleteWardenSyncQueuePayload {
   """
@@ -11517,6 +11499,39 @@ type DeleteSignalClusterPayload {
 
 """All input for the `deleteSignalCluster` mutation."""
 input DeleteSignalClusterInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  rowId: UUID!
+}
+
+"""The output of our delete `StatusTemplate` mutation."""
+type DeleteStatusTemplatePayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `StatusTemplate` that was deleted by this mutation."""
+  statusTemplate: StatusTemplate
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `StatusTemplate`. May be used by Relay 1."""
+  statusTemplateEdge(
+    """The method to use when ordering `StatusTemplate`."""
+    orderBy: [StatusTemplateOrderBy!]! = [PRIMARY_KEY_ASC]
+  ): StatusTemplateEdge
+}
+
+"""All input for the `deleteStatusTemplate` mutation."""
+input DeleteStatusTemplateInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.
@@ -11738,17 +11753,17 @@ type Query implements Node {
   """Get a single `Attachment`."""
   attachment(rowId: UUID!): Attachment
 
-  """Get a single `StatusTemplate`."""
-  statusTemplate(rowId: UUID!): StatusTemplate
-
-  """Get a single `StatusTemplate`."""
-  statusTemplateByOrganizationIdAndName(organizationId: UUID!, name: String!): StatusTemplate
-
   """Get a single `WardenSyncQueue`."""
   wardenSyncQueue(rowId: UUID!): WardenSyncQueue
 
   """Get a single `SignalCluster`."""
   signalCluster(rowId: UUID!): SignalCluster
+
+  """Get a single `StatusTemplate`."""
+  statusTemplate(rowId: UUID!): StatusTemplate
+
+  """Get a single `StatusTemplate`."""
+  statusTemplateByOrganizationIdAndName(organizationId: UUID!, name: String!): StatusTemplate
 
   """Get a single `Signal`."""
   signal(rowId: UUID!): Signal
@@ -12142,40 +12157,6 @@ type Query implements Node {
     orderBy: [AttachmentOrderBy!] = [PRIMARY_KEY_ASC]
   ): AttachmentConnection
 
-  """Reads and enables pagination through a set of `StatusTemplate`."""
-  statusTemplates(
-    """Only read the first `n` values of the set."""
-    first: Int
-
-    """Only read the last `n` values of the set."""
-    last: Int
-
-    """
-    Skip the first `n` values from our `after` cursor, an alternative to cursor
-    based pagination. May not be used with `last`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: StatusTemplateCondition
-
-    """
-    A filter to be used in determining which values should be returned by the collection.
-    """
-    filter: StatusTemplateFilter
-
-    """The method to use when ordering `StatusTemplate`."""
-    orderBy: [StatusTemplateOrderBy!] = [PRIMARY_KEY_ASC]
-  ): StatusTemplateConnection
-
   """Reads and enables pagination through a set of `WardenSyncQueue`."""
   wardenSyncQueues(
     """Only read the first `n` values of the set."""
@@ -12243,6 +12224,40 @@ type Query implements Node {
     """The method to use when ordering `SignalCluster`."""
     orderBy: [SignalClusterOrderBy!] = [PRIMARY_KEY_ASC]
   ): SignalClusterConnection
+
+  """Reads and enables pagination through a set of `StatusTemplate`."""
+  statusTemplates(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: StatusTemplateCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: StatusTemplateFilter
+
+    """The method to use when ordering `StatusTemplate`."""
+    orderBy: [StatusTemplateOrderBy!] = [PRIMARY_KEY_ASC]
+  ): StatusTemplateConnection
 
   """Reads and enables pagination through a set of `Signal`."""
   signals(
@@ -12445,14 +12460,6 @@ type Mutation {
     input: CreateAttachmentInput!
   ): CreateAttachmentPayload
 
-  """Creates a single `StatusTemplate`."""
-  createStatusTemplate(
-    """
-    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    """
-    input: CreateStatusTemplateInput!
-  ): CreateStatusTemplatePayload
-
   """Creates a single `WardenSyncQueue`."""
   createWardenSyncQueue(
     """
@@ -12468,6 +12475,14 @@ type Mutation {
     """
     input: CreateSignalClusterInput!
   ): CreateSignalClusterPayload
+
+  """Creates a single `StatusTemplate`."""
+  createStatusTemplate(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateStatusTemplateInput!
+  ): CreateStatusTemplatePayload
 
   """Creates a single `Project`."""
   createProject(
@@ -12565,14 +12580,6 @@ type Mutation {
     input: UpdateAttachmentInput!
   ): UpdateAttachmentPayload
 
-  """Updates a single `StatusTemplate` using a unique key and a patch."""
-  updateStatusTemplate(
-    """
-    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    """
-    input: UpdateStatusTemplateInput!
-  ): UpdateStatusTemplatePayload
-
   """Updates a single `WardenSyncQueue` using a unique key and a patch."""
   updateWardenSyncQueue(
     """
@@ -12588,6 +12595,14 @@ type Mutation {
     """
     input: UpdateSignalClusterInput!
   ): UpdateSignalClusterPayload
+
+  """Updates a single `StatusTemplate` using a unique key and a patch."""
+  updateStatusTemplate(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateStatusTemplateInput!
+  ): UpdateStatusTemplatePayload
 
   """Updates a single `Project` using a unique key and a patch."""
   updateProject(
@@ -12685,14 +12700,6 @@ type Mutation {
     input: DeleteAttachmentInput!
   ): DeleteAttachmentPayload
 
-  """Deletes a single `StatusTemplate` using a unique key."""
-  deleteStatusTemplate(
-    """
-    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    """
-    input: DeleteStatusTemplateInput!
-  ): DeleteStatusTemplatePayload
-
   """Deletes a single `WardenSyncQueue` using a unique key."""
   deleteWardenSyncQueue(
     """
@@ -12708,6 +12715,14 @@ type Mutation {
     """
     input: DeleteSignalClusterInput!
   ): DeleteSignalClusterPayload
+
+  """Deletes a single `StatusTemplate` using a unique key."""
+  deleteStatusTemplate(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteStatusTemplateInput!
+  ): DeleteStatusTemplatePayload
 
   """Deletes a single `Project` using a unique key."""
   deleteProject(

--- a/src/lib/db/schema/statusTemplate.table.ts
+++ b/src/lib/db/schema/statusTemplate.table.ts
@@ -31,6 +31,10 @@ export const statusTemplates = pgTable(
     // null = fall back to the default roadmap heuristic; true/false = explicit
     // admin choice for whether this status appears on the public roadmap
     showOnRoadmap: boolean(),
+    // null = fall back to the default board heuristic; true/false = explicit
+    // admin choice for whether this status is shown by default on the board
+    // (terminal statuses like completed/closed are hidden by default)
+    showOnBoard: boolean(),
     // Marks this template as the target a magic-word keyword (closes/fixes/
     // resolves) transitions a post to. null = not a keyword target; the parser
     // falls back to the seeded `completed`/`closed` names. At most one per org


### PR DESCRIPTION
## Description

Adds a nullable `show_on_board` boolean to `status_template`, mirroring the existing `show_on_roadmap`.

- `null` falls back to the app's default board heuristic (terminal statuses like `completed`/`closed` are hidden by default)
- `true`/`false` is an explicit per-status admin choice

This is the API half of hiding resolved feedback from the board by default (the app reads/toggles the flag). Migration `0029` is additive (nullable column, no backfill). Regenerated `schema.graphql` and `schema.executable.ts`.

## Test Steps

1. Run migrations; confirm `status_template.show_on_board` exists and is nullable
2. Query `statusTemplates { nodes { showOnBoard } }` and confirm the field resolves
3. `updateStatusTemplate(input: { rowId, patch: { showOnBoard: false } })` persists